### PR TITLE
Fixed issue of not properly deleting entities on surface change.

### DIFF
--- a/PersonalTransformer2/changelog.txt
+++ b/PersonalTransformer2/changelog.txt
@@ -1,4 +1,14 @@
 ---------------------------------------------------------------------------------------------------
+Version: 0.1.16
+  Bugfix: 
+    - Fixed issue of not properly deleting entities on surface change.
+	- To manually remove existing entities run this command (WARNING: Will disable achievements): /c 	for _, surface in pairs(game.surfaces) do for _, ent in pairs (surface.find_entities_filtered({name={"personal-transformer-input-entity", "personal-transformer-output-entity", "personal-transformer-mk2-input-entity", "personal-transformer-mk2-output-entity", "personal-transformer-mk3-input-entity", "personal-transformer-mk3-output-entity"}})) do ent.destroy() end end
+  Current Bugs:
+    - Vehicles do not drain energy properly. Vehicles can power the network but no drain from batteries currently occurs.
+    - Transformers do NOT work if you put them in after other equipment in vehicle grids. No idea why. 
+    - Despite these bugs I've released this so that people could at least attempt to use the functionality. If you've got a fix, please let me know!
+
+---------------------------------------------------------------------------------------------------
 Version: 0.1.15
   Bugfix:
     - Removed some incessant log statements.

--- a/PersonalTransformer2/control.lua
+++ b/PersonalTransformer2/control.lua
@@ -731,7 +731,6 @@ function removeInputOutputTransformerEntities(playerIndex, old_surface_index, ch
 	if t == nil then
 		return
 	end
---update_personal_transformer(tickdelay, char_armor_transformers.trans2, 'personal-transformer-mk2-equipment', 'personal-transformer-mk2-input-entity', 'personal-transformer-mk2-output-entity', mk2_draw)
 	-- if character suface is not the old surface, ie if character changed surfaces
 	if t.surface_index ~= old_surface_index then
 --		log ('RemoveI/O Transformer Entities. ')

--- a/PersonalTransformer2/control.lua
+++ b/PersonalTransformer2/control.lua
@@ -55,7 +55,6 @@ script.on_load(
 	end
 )
 
-
 script.on_configuration_changed(
 	function(data)
 	-- global.grid_vehicles = {}
@@ -732,6 +731,7 @@ function removeInputOutputTransformerEntities(playerIndex, old_surface_index, ch
 	if t == nil then
 		return
 	end
+--update_personal_transformer(tickdelay, char_armor_transformers.trans2, 'personal-transformer-mk2-equipment', 'personal-transformer-mk2-input-entity', 'personal-transformer-mk2-output-entity', mk2_draw)
 	-- if character suface is not the old surface, ie if character changed surfaces
 	if t.surface_index ~= old_surface_index then
 --		log ('RemoveI/O Transformer Entities. ')
@@ -739,14 +739,19 @@ function removeInputOutputTransformerEntities(playerIndex, old_surface_index, ch
 --		log ('Player Inputs: ' .. serpent.block(t.inputs))
 --		log ('Table to Remove Inputs: ' .. serpent.block(char_table[playerIndex].inputs))
 --		log ('Table to Remove Inputs Size: ' .. serpent.block(#t.inputs))
+		char_table[playerIndex] = nil
 		count = #t.inputs
 		for i = 0, count do 
-			t.inputs[i] = nil 
+			if t.inputs[i] ~= nil then
+				t.inputs[i].destroy()
+			end
 		end
 
 		count = #t.outputs
 		for i = 0, count do
-			t.outputs[i] = nil
+			if t.outputs[i] ~= nil then
+				t.outputs[i].destroy()
+			end
 		end
 	end
 end

--- a/PersonalTransformer2/info.json
+++ b/PersonalTransformer2/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "PersonalTransformer2",
-	"version": "0.1.15",
+	"version": "0.1.16",
 	"title": "Personal Transformer2",
 	"author": "Pikachar",
 	


### PR DESCRIPTION
Fixed issue of not properly deleting entities on surface change.
 To manually remove existing entities run this command (WARNING: Will disable achievements): 
 `/c 	for _, surface in pairs(game.surfaces) do for _, ent in pairs (surface.find_entities_filtered({name={"personal-transformer-input-entity", "personal-transformer-output-entity", "personal-transformer-mk2-input-entity", "personal-transformer-mk2-output-entity", "personal-transformer-mk3-input-entity", "personal-transformer-mk3-output-entity"}})) do ent.destroy() end end`
