### PR TITLE
Added Tick Delay Setting

### DIFF
--- a/PersonalTransformer2/changelog.txt
+++ b/PersonalTransformer2/changelog.txt
@@ -1,4 +1,13 @@
 ---------------------------------------------------------------------------------------------------
+Version: 0.1.17
+  Features:
+    - Added 'Set Tick Delay' setting for allowing control of how often the code runs updates.
+  Current Bugs:
+    - Vehicles do not drain energy properly. Vehicles can power the network but no drain from batteries currently occurs.
+    - Transformers do NOT work if you put them in after other equipment in vehicle grids. No idea why. 
+    - Despite these bugs I've released this so that people could at least attempt to use the functionality. If you've got a fix, please let me know!
+
+---------------------------------------------------------------------------------------------------
 Version: 0.1.16
   Bugfix: 
     - Fixed issue of not properly deleting entities on surface change.

--- a/PersonalTransformer2/control.lua
+++ b/PersonalTransformer2/control.lua
@@ -2,7 +2,10 @@ local char_armor_transformers = nil
 local vehicle_armor_transformers = nil
 local my_types = {"car", "spider-vehicle", "rolling-stock"}
 
-local tickdelay = 1
+-- This is a delay constant for controlling how often the transformer script runs. The mod will behave reasonably for any value from 1 to 6.
+-- Lower values are more UPS intensive but have finer updates, while higher values are less UPS intensive but have coarser updates.
+--local tickdelay = 10
+local tickdelay = settings.global["personal-transformer2-tick-delay"].value
 
 local mk1_draw = 200000
 local mk2_draw = 1000000
@@ -254,6 +257,8 @@ script.on_event(defines.events.on_lua_shortcut,
 script.on_event(defines.events.on_tick,
 	function(event)
 		
+		tickdelay = settings.global["personal-transformer2-tick-delay"].value
+
 		if event.tick % tickdelay ~= 0 then
 			return
 		end
@@ -309,7 +314,7 @@ function update_personal_transformer(tickdelay, char_table, equip_name, input_na
 				if not p.is_shortcut_toggled('toggle-equipment-transformer-output') then
 					max_draw_out = 0
 				end
-				-- get position of entity
+				-- get position of player
 				local pos = p.position
 				-- cleans up old personal-transformer-input/output entities
 				if transformer_count ~= #t.outputs then
@@ -366,6 +371,7 @@ function update_personal_transformer(tickdelay, char_table, equip_name, input_na
 						v.teleport(pos)
 						request_out = request_out + (buffer - v.energy)
 					end
+					-- Power Calculations begin.
 					local drain_in, drain_out, ratio_in, ratio_out = nil
 					if avail_in == 0 then
 						drain_in = 0

--- a/PersonalTransformer2/info.json
+++ b/PersonalTransformer2/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "PersonalTransformer2",
-	"version": "0.1.15",
+	"version": "0.1.17",
 	"title": "Personal Transformer2",
 	"author": "Pikachar",
 	

--- a/PersonalTransformer2/locale/en/locale.cfg
+++ b/PersonalTransformer2/locale/en/locale.cfg
@@ -36,6 +36,9 @@ personal-transformer-mk3-equipment=Allows the player to cause blackouts at outpo
 
 [mod-setting-name]
 personal-transformer2-allow-non-armor=Allow Personal Transformer in non-armor grids (BETA)
+personal-transformer2-tick-delay=Set Tick Delay
 
 [mod-setting-description]
 personal-transformer2-allow-non-armor=Allow Personal Transformer to be placed in non-armor grids.
+personal-transformer2-tick-delay=This is a delay constant for controlling how often the transformer script runs. The mod will behave reasonably for any value from 1 to 6. Lower values are more UPS intensive but have finer updates, while higher values are less UPS intensive but have coarser updates.
+

--- a/PersonalTransformer2/settings.lua
+++ b/PersonalTransformer2/settings.lua
@@ -7,5 +7,15 @@ data:extend
     default_value = false,
     per_user = false,
     order = "a1"
+  },
+  {
+    type = "int-setting",
+    name = "personal-transformer2-tick-delay",
+    setting_type = "runtime-global",
+	minimum_value = 1,
+	maximum_value = 60,
+    default_value = 1,
+    per_user = false,
+    order = "a2"
   }
 }


### PR DESCRIPTION
Added Tick Delay Setting
-- This is a delay constant for controlling how often the transformer script runs. The mod will behave reasonably for any value from 1 to 6.
-- Lower values are more UPS intensive but have finer updates, while higher values are less UPS intensive but have coarser updates.
