### PR TITLE
Version 1.0.0 

### DIFF
--- a/PersonalTransformer2/changelog.txt
+++ b/PersonalTransformer2/changelog.txt
@@ -7,7 +7,9 @@ Version: 1.0.0
   Bugfix:
     - Fixed several crashes introduced in 0.1.18 despite the fact I swear I tested those scenarios
 	- Fixed case where when a train was cloned it would leave duplicates of the invisible transformers lying around.
+	- Fixed case where infinite energy could be created with both input and output on.
   Note:
+    - Remove all transformers from grids upon updating.
     - Biggest performance hits are on having a large amount of other gear in your grid. If you can think of a way to improve this, please let me know.
 	
 ---------------------------------------------------------------------------------------------------

--- a/PersonalTransformer2/changelog.txt
+++ b/PersonalTransformer2/changelog.txt
@@ -1,4 +1,12 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.0.0
+  Features:
+    - Added settings to allow for the configuration of the flow rate of each transformer.
+	- Removed Beta tag from 'Allow Personal Transformer in non-armor Grids' setting.
+  Note:
+    - Biggest performance hits are on having a large amount of other gear in your grid. If you can think of a way to improve this, please let me know.
+	
+---------------------------------------------------------------------------------------------------
 Version: 0.1.18
   Optimizations:
     - Refactored for performance. Got about a 30% improvement in my SE factory I was testing on.

--- a/PersonalTransformer2/changelog.txt
+++ b/PersonalTransformer2/changelog.txt
@@ -3,6 +3,10 @@ Version: 1.0.0
   Features:
     - Added settings to allow for the configuration of the flow rate of each transformer.
 	- Removed Beta tag from 'Allow Personal Transformer in non-armor Grids' setting.
+    - Added ability to enable/disable the ability to use the shortcuts in most scenarios.
+  Bugfix:
+    - Fixed several crashes introduced in 0.1.18 despite the fact I swear I tested those scenarios
+	- Fixed case where when a train was cloned it would leave duplicates of the invisible transformers lying around.
   Note:
     - Biggest performance hits are on having a large amount of other gear in your grid. If you can think of a way to improve this, please let me know.
 	
@@ -48,7 +52,7 @@ Version: 0.1.15
 ---------------------------------------------------------------------------------------------------
 Version: 0.1.14
   Bugfix:
-    - Fixed issue where having multiple Personal Transformers in your armor when on a space ship that changes surface would crash the game.
+    - SE: Fixed issue where having multiple Personal Transformers in your armor when on a space ship that changes surface would crash the game.
   Current Bugs:
     - Vehicles do not drain energy properly. Vehicles can power the network but no drain from batteries currently occurs.
     - Transformers do NOT work if you put them in after other equipment in vehicle grids. No idea why. 

--- a/PersonalTransformer2/control.lua
+++ b/PersonalTransformer2/control.lua
@@ -364,7 +364,7 @@ function update_personal_transformer(tickdelay, transformer_data)
 				if grid ~= nil then
 				-- perform math
 					for _, v in pairs(grid.equipment) do
-						if not is_personal_transformer_name_match(v.name) and v.prototype.energy_source ~= nil then
+						if v.prototype.energy_source ~= nil then
 							-- if energy source calculate max_draw_in/out from equipment with flow limit
 							-- ie, what's the flow rate of the generators/batteries
 							-- toggle off appropriate draw if toggle is off
@@ -424,7 +424,8 @@ function update_personal_transformer(tickdelay, transformer_data)
 						if gt_entity.type == 'electric-energy-interface' then
 							gt_entity.energy = gt_entity.energy * (1 - drain_in)
 						else
-							gt_entity.energy = buffer - ((buffer - gt_entity.energy) * (1 - drain_out))
+							local entity_buffer = gt_entity.electric_buffer_size
+							gt_entity.energy = entity_buffer - ((entity_buffer - gt_entity.energy) * (1 - drain_out))
 						end
 					end
 					----
@@ -522,7 +523,8 @@ function update_vehicle_transformer(tickdelay, transformer_data)
 						if gt_entity.type == 'electric-energy-interface' then
 							gt_entity.energy = gt_entity.energy * (1 - drain_in)
 						else
-							gt_entity.energy = buffer - ((buffer - gt_entity.energy) * (1 - drain_out))
+							local entity_buffer = gt_entity.electric_buffer_size
+							gt_entity.energy = entity_buffer - ((entity_buffer - gt_entity.energy) * (1 - drain_out))
 						end
 					end
 					----

--- a/PersonalTransformer2/control.lua
+++ b/PersonalTransformer2/control.lua
@@ -471,7 +471,7 @@ function update_vehicle_transformer(tickdelay, transformer_data)
 				if grid ~= nil then
 				-- perform math
 					for _, v in pairs(grid.equipment) do
-						if not is_personal_transformer_name_match(v.name) and v.prototype.energy_source ~= nil then
+						if v.prototype.energy_source ~= nil then
 							-- if energy source calculate max_draw_in/out from equipment with flow limit
 							-- ie, what's the flow rate of the generators/batteries
 							-- toggle off appropriate draw if toggle is off

--- a/PersonalTransformer2/control.lua
+++ b/PersonalTransformer2/control.lua
@@ -197,7 +197,7 @@ script.on_event(defines.events.on_entity_cloned,
 	function(event)
 		log ('on_entity_cloned start --- ')
 		new_vehicle_placed(event.destination)
-
+--[[
 		if event.source.grid then
 			local grid_id = event.source.grid.unique_id
 				for index, et in ipairs (global.transformer_data[grid_id].grid_transformer_entities) do
@@ -206,24 +206,14 @@ script.on_event(defines.events.on_entity_cloned,
 					entity = nil
 				end
 		end
-		
+--]]		
 		purgeOrphanedEntities()		
 	end
 	-- {LuaPlayerBuiltEntityEventFilters = {"vehicle"}} -- incorrect way
 	-- ,{{filter = "name", name = "vehicle"}}
 , vehicle_event_filters
 )
---[[
-script.on_event(defines.events.on_entity_cloned, 
-	function(event)
-		log ('on_entity_cloned start PT EVENT--- ')
---		new_vehicle_placed(event.destination)
-	end
-	-- {LuaPlayerBuiltEntityEventFilters = {"vehicle"}} -- incorrect way
-	-- ,{{filter = "name", name = "vehicle"}}
-, pt_entity_event_filters
-)
---]]
+
 script.on_event(defines.events.script_raised_built, 
 	function(event)
 log ('script_raised_built --- ')
@@ -322,22 +312,28 @@ script.on_event(defines.events.script_raised_teleported,
 
 script.on_event(defines.events.on_player_driving_changed_state, 
 	function(event)
-		log ('on_player_driving_changed_state start --- ')
-		listCurrentAndAllPTEntities()
+--		log ('on_player_driving_changed_state start --- ')
+--		listCurrentAndAllPTEntities()
 	end
 )
 
 script.on_event(defines.events.on_lua_shortcut,
 	function(event)
-		if event.prototype_name == 'toggle-equipment-transformer-input' then
+--log ('on_player_driving_changed_state start --- ')
+		if event.prototype_name == 'toggle-equipment-transformer-input' or event.prototype_name == 'toggle-equipment-transformer-output' then
 			local player = game.players[event.player_index]
-			player.set_shortcut_toggled('toggle-equipment-transformer-input', not player.is_shortcut_toggled('toggle-equipment-transformer-input'))
-		elseif event.prototype_name == 'toggle-equipment-transformer-output' then
-			local player = game.players[event.player_index]
-			player.set_shortcut_toggled('toggle-equipment-transformer-output', not player.is_shortcut_toggled('toggle-equipment-transformer-output'))
+			if event.prototype_name == 'toggle-equipment-transformer-input' then
+				player.set_shortcut_toggled('toggle-equipment-transformer-input', not player.is_shortcut_toggled('toggle-equipment-transformer-input'))
+			elseif event.prototype_name == 'toggle-equipment-transformer-output' then
+				player.set_shortcut_toggled('toggle-equipment-transformer-output', not player.is_shortcut_toggled('toggle-equipment-transformer-output'))
+			end
+			-- NOTE put code here to remove and re-add entities
+--			if not player.is_shortcut_toggled('toggle-equipment-transformer-input') and not player.is_shortcut_toggled('toggle-equipment-transformer-output') then
+--				playerOrArmorChanged(event.player_index)
+--			end
 		end
-		-- NOTE put code here to remove and re-add entities
-	end)
+	end
+)
 
 script.on_event(defines.events.on_tick,
 	function(event)
@@ -898,7 +894,10 @@ function entityTeleported(entity)
 end
 
 function purgeOrphanedEntities()
-	log ('purgeOrphanedEntities --- all entities: ')
+--	log ('purgeOrphanedEntities --- all entities: ')
+	if not isVehicleGridAllowed then
+		return
+	end
 
 	local current_entities = {}
 	for gd_id, transformer_data_values in pairs(global.transformer_data) do
@@ -917,10 +916,12 @@ function purgeOrphanedEntities()
 			end
 		end 
 	end
-	log ('purgeOrphanedEntities --- AFTER: ')
-	listCurrentAndAllPTEntities()
+--	log ('purgeOrphanedEntities --- AFTER: ')
+--	listCurrentAndAllPTEntities()
 end
 
+
+-------- Utility Methods ---------
 function tableContains(testTable, value)
 	for i = 1, #testTable do
 		if (testTable[i] == value) then

--- a/PersonalTransformer2/control.lua
+++ b/PersonalTransformer2/control.lua
@@ -66,9 +66,9 @@ script.on_init(
 
 script.on_load(
 	function()
-		log ('on_load --- mk1_draw: ' .. serpent.block(mk1_draw))
-		log ('on_load --- mk2_draw: ' .. serpent.block(mk2_draw))
-		log ('on_load --- mk3_draw: ' .. serpent.block(mk3_draw))
+--		log ('on_load --- mk1_draw: ' .. serpent.block(mk1_draw))
+--		log ('on_load --- mk2_draw: ' .. serpent.block(mk2_draw))
+--		log ('on_load --- mk3_draw: ' .. serpent.block(mk3_draw))
 
 	end
 )
@@ -100,7 +100,7 @@ script.on_configuration_changed(
 script.on_event(defines.events.on_equipment_inserted,
 	function(event)
 -- CHARACTER CODE
---		log ('on_equipment_inserted start --- ')
+		log ('on_equipment_inserted start --- ')
 		local grid_id = event.grid.unique_id
 		local player = isPlayerOwnerOfGrid(grid_id)
 		
@@ -113,13 +113,13 @@ script.on_event(defines.events.on_equipment_inserted,
 		if not isVehicleGridAllowed then
 			return
 		end
---log ('on_equipment_inserted vehicle grids allowed --- ')
+log ('on_equipment_inserted vehicle grids allowed --- ')
 		local valid_vehicle = global.grid_vehicles[grid_id] -- and global.grid_vehicles[grid_id].entity
---log ('on_equipment_inserted vehicle grid_id --- ' .. serpent.block(grid_id))
---log ('on_equipment_inserted grid_vehicles --- ' .. serpent.block(global.grid_vehicles))
---log ('on_equipment_inserted vehicle --- ' .. serpent.block(valid_vehicle))
+log ('on_equipment_inserted vehicle grid_id --- ' .. serpent.block(grid_id))
+log ('on_equipment_inserted grid_vehicles --- ' .. serpent.block(global.grid_vehicles))
+log ('on_equipment_inserted vehicle --- ' .. serpent.block(valid_vehicle))
 		if valid_vehicle and valid_vehicle.valid then
---log ('on_equipment_inserted valid vehicle --- ')
+log ('on_equipment_inserted valid vehicle --- ')
 			equipmentInserted(valid_vehicle, grid_id, event.equipment.name, "entity")
 		end
 	end
@@ -185,6 +185,7 @@ log ('on_robot_built_entity --- ')
 
 script.on_event(defines.events.on_entity_cloned, 
 	function(event)
+		log ('on_entity_cloned start --- ')
 		new_vehicle_placed(event.destination)
 	end
 	-- {LuaPlayerBuiltEntityEventFilters = {"vehicle"}} -- incorrect way
@@ -214,7 +215,7 @@ log ('script_raised_revive --- ')
 
 script.on_event(defines.events.on_player_mined_entity, 
 	function(event)
---		log ('on_player_mined_entity start --- ')
+		log ('on_player_mined_entity start --- ')
 		entity_removed(event.entity)
 	end
 	-- {LuaPlayerBuiltEntityEventFilters = {"vehicle"}} -- incorrect way
@@ -297,6 +298,7 @@ script.on_event(defines.events.on_lua_shortcut,
 			local player = game.players[event.player_index]
 			player.set_shortcut_toggled('toggle-equipment-transformer-output', not player.is_shortcut_toggled('toggle-equipment-transformer-output'))
 		end
+		-- NOTE put code here to remove and re-add entities
 	end)
 
 script.on_event(defines.events.on_tick,
@@ -431,6 +433,12 @@ function update_vehicle_transformer(tickdelay, transformer_data)
 
 			if vehicle and vehicle.valid then
 				-- teleport entities to vehicle
+--log ('update_vehicle_transformer --- global.grid_vehicles = '.. serpent.block(global.grid_vehicles))
+--log ('update_vehicle_transformer --- global.transformer_data: ' .. serpent.block(global.transformer_data))
+--log ('update_vehicle_transformer --- loop')
+--log ('update_vehicle_transformer --- grid_id = '.. serpent.block(grid_id))
+--log ('update_vehicle_transformer --- vehicle.position = '.. serpent.block(vehicle.position))
+--log ('update_vehicle_transformer --- transformer_data_values.grid_transformer_entities = '.. serpent.block(transformer_data_values.grid_transformer_entities))
 				teleportEntitiesToPlayerPosition(vehicle.position, transformer_data_values.grid_transformer_entities)
 				local grid = vehicle.grid
 				if grid ~= nil then
@@ -558,27 +566,45 @@ function remove_entity(equipment_name, grid_id)
 
 		local input_check = false
 		local output_check = false
---log ('remove_entity --- grid_id: ' .. serpent.block(grid_id))
+--log ('remove_entity --- START grid_id: ' .. serpent.block(grid_id))
 --log ('remove_entity --- global.transformer_data: ' .. serpent.block(global.transformer_data))
-		for index, entity in ipairs (global.transformer_data[grid_id].grid_transformer_entities) do 
+--log ('remove_entity --- global.transformer_data_entities1: ' .. serpent.block(global.transformer_data[grid_id].grid_transformer_entities[1].name))
+--log ('remove_entity --- global.transformer_data_entities2: ' .. serpent.block(global.transformer_data[grid_id].grid_transformer_entities[2].name))
+
+		for index, entity in ipairs (global.transformer_data[grid_id].grid_transformer_entities) do
+--		for index = 1, count do
+--			local entity = global.transformer_data[grid_id].grid_transformer_entities[index]
+--log ('remove_entity --- index: ' .. serpent.block(index))
+--log ('remove_entity --- entity: ' .. serpent.block(entity))
+--log ('remove_entity --- entity.name: ' .. serpent.block(entity.name))
 			if (entity.name == entity_input_name) then
 				local entity = table.remove(global.transformer_data[grid_id].grid_transformer_entities, index)
 --				log ('remove_entity --- entity: ' .. serpent.block(entity))
 				entity.destroy()
 				entity = nil
 				input_check = true
-			elseif (entity.name == entity_output_name) then
+				break
+			end
+		end
+
+		for index, entity in ipairs (global.transformer_data[grid_id].grid_transformer_entities) do
+--			local entity = global.transformer_data[grid_id].grid_transformer_entities[index]
+--log ('remove_entity --- index: ' .. serpent.block(index))
+--log ('remove_entity --- entity: ' .. serpent.block(entity))
+--log ('remove_entity --- entity.name: ' .. serpent.block(entity.name))
+			if (entity.name == entity_output_name) then
 				local entity = table.remove(global.transformer_data[grid_id].grid_transformer_entities, index)
 --				log ('remove_entity --- entity: ' .. serpent.block(entity))
 				entity.destroy()
 				entity = nil
 				output_check = true
-			end
-			if input_check and output_check then
-				return
+				break
 			end
 		end
+--		log ('remove_entity --- global.transformer_data post removal: ' .. serpent.block(global.transformer_data))
 	end
+--log ('remove_entity --- grid_id: ' .. serpent.block(grid_id))
+--log ('remove_entity --- END global.transformer_data: ' .. serpent.block(global.transformer_data))
 end
 
 function new_vehicle_placed_event_wrapper(event)
@@ -607,31 +633,20 @@ function new_vehicle_placed(entity)
 		local mk1_count = grid.count(personal_transformer_mk1_name)
 		local mk2_count = grid.count(personal_transformer_mk2_name)
 		local mk3_count = grid.count(personal_transformer_mk3_name)
-		local draw_total = (mk1_count * mk1_draw) + (mk2_count * mk2_draw) + (mk3_count * mk3_draw)
-		if draw_total > 0 then
-			if not global.transformer_data[grid_id] then 
-				global.transformer_data[grid_id] = {}
-				global.transformer_data[grid_id].grid_transformer_entities = {}
+		if mk1_count > 0 then
+			for i = 1, mk1_count do
+				equipmentInserted(vehicle, grid_id, personal_transformer_mk1_name, "entity")
 			end
-
-			global.transformer_data[grid_id].max_grid_draw = draw_total
-
-			if mk1_count > 0 then
-				for i = 1, mk1_count do
-					equipmentInserted(vehicle, grid_id, personal_transformer_mk1_name, "entity")
-				end
+		end
+		if mk2_count > 0 then
+			for i = 1, mk2_count do
+				equipmentInserted(vehicle, grid_id, personal_transformer_mk2_name, "entity")
 			end
-			if mk2_count > 0 then
-				for i = 1, mk2_count do
-					equipmentInserted(vehicle, grid_id, personal_transformer_mk2_name, "entity")
-				end
+		end
+		if mk3_count > 0 then
+			for i = 1, mk3_count do
+				equipmentInserted(vehicle, grid_id, personal_transformer_mk3_name, "entity")
 			end
-			if mk3_count > 0 then
-				for i = 1, mk3_count do
-					equipmentInserted(vehicle, grid_id, personal_transformer_mk3_name, "entity")
-				end
-			end
-	
 		end
 	end
 --	log ('new_vehicle_placed end --- global.transformer_data: ' .. serpent.block(global.transformer_data))
@@ -642,6 +657,7 @@ function entity_removed(entity)
 --	log ('entity_removed start --- global.transformer_data: ' .. serpent.block(global.transformer_data))
 --	log ('entity_removed start --- global.grid_vehicles: ' .. serpent.block(global.grid_vehicles))
 --	log ('entity_removed start --- entity.unit_number: ' .. serpent.block(entity.unit_number))
+	log ('entity_removed start --- entity.type: ' .. serpent.block(entity.type))
 --	log ('entity_removed start --- vehicle_grid:4200: unit_number ' .. serpent.block(global.grid_vehicles[4200].unit_number))
 	if not isVehicleGridAllowed then
 		return
@@ -649,7 +665,7 @@ function entity_removed(entity)
 	local grid_id
 	for index, vehicle_entity in pairs (global.grid_vehicles) do 
 		-- See: https://lua-api.factorio.com/latest/classes/LuaEntity.html#unit_number
---log ('entity_removed start --- index ' .. serpent.block(index))
+log ('entity_removed start --- index ' .. serpent.block(index))
 --		if entity.unit_number == vehicle_entity.unit_number then
 		if entity == vehicle_entity then
 			grid_id = index
@@ -658,15 +674,18 @@ function entity_removed(entity)
 			for grid_id, transformer_data_values in pairs(global.transformer_data) do
 				if transformer_data_values.grid_owner_type == "entity" and transformer_data_values.grid_owner_id == grid_id then
 					for count_key, count_value in pairs(transformer_data_values.transformer_count) do
-						equipmentRemoved(grid_id, count_key, count_value)
+						if count_value > 0 then
+log ('entity_removed --- grid_id: ' .. serpent.block(grid_id))
+							equipmentRemoved(grid_id, count_key, count_value)
+						end
 					end
 				end
 			end
 			break
 		end
 	end
---	log ('entity_removed end --- global.transformer_data: ' .. serpent.block(global.transformer_data))
---	log ('entity_removed end --- global.grid_vehicles: ' .. serpent.block(global.grid_vehicles))
+	log ('entity_removed end --- global.transformer_data: ' .. serpent.block(global.transformer_data))
+	log ('entity_removed end --- global.grid_vehicles: ' .. serpent.block(global.grid_vehicles))
 end
 
 function isPlayerOwnerOfGrid(grid_id)
@@ -691,7 +710,7 @@ function teleportEntitiesToPlayerPosition(player_pos, grid_transformer_entities)
 end
 
 function equipmentInserted(player, grid_id, equipment_name, grid_owner_type)
---	log ('on_inserted equipment before --- global.transformer_data: ' .. serpent.block(global.transformer_data))
+	log ('equipmentInserted before --- global.transformer_data: ' .. serpent.block(global.transformer_data))
 	if is_personal_transformer_name_match(equipment_name) then
 		if not global.transformer_data[grid_id] then 
 			global.transformer_data[grid_id] = {}
@@ -719,19 +738,19 @@ function equipmentInserted(player, grid_id, equipment_name, grid_owner_type)
 		end
 		global.transformer_data[grid_id].max_grid_draw = global.transformer_data[grid_id].max_grid_draw + transformer_draw[equipment_name]
 		global.transformer_data[grid_id].buffer = global.transformer_data[grid_id].max_grid_draw / 10
---	log ('on_inserted equipment after --- global.transformer_data after: ' .. serpent.block(global.transformer_data))
+	log ('equipmentInserted after --- global.transformer_data after: ' .. serpent.block(global.transformer_data))
 	end
 end
 
 function equipmentRemoved(grid_id, equipment_name, count)
 	if is_personal_transformer_name_match(equipment_name) then
+		log ('on_equipment_removed before --- global.transformer_data: ' .. serpent.block(global.transformer_data))
+		log ('on_equipment_removed --- grid_id: ' .. serpent.block(grid_id))
+		log ('on_equipment_removed --- count: ' .. serpent.block(count))
+		log ('on_equipment_removed --- equipment_name: ' .. serpent.block(equipment_name))
 		for i = 1, count do 
 			remove_entity(equipment_name, grid_id)
 		end
---		log ('on_equipment_removed before --- global.transformer_data: ' .. serpent.block(global.transformer_data))
---		log ('on_equipment_removed --- grid_id: ' .. serpent.block(grid_id))
---		log ('on_equipment_removed --- count: ' .. serpent.block(count))
---		log ('on_equipment_removed --- equipment_name: ' .. serpent.block(equipment_name))
 --		log ('on_equipment_removed --- global.transformer_data.transformer_count[array]: ' .. serpent.block(global.transformer_data[grid_id].transformer_count[personal_transformer_mk3_name]))
 		global.transformer_data[grid_id].transformer_count[equipment_name] = global.transformer_data[grid_id].transformer_count[equipment_name] - count
 --		log ('on_equipment_removed post remove entity --- global.transformer_data after: ' .. serpent.block(global.transformer_data))
@@ -750,11 +769,12 @@ function equipmentRemoved(grid_id, equipment_name, count)
 			global.transformer_data[grid_id] = nil
 		end
 	end
---	log ('on_equipment_removed after --- global.transformer_data: ' .. serpent.block(global.transformer_data))
+	log ('on_equipment_removed after --- grid_id: ' .. serpent.block(grid_id))
+	log ('on_equipment_removed after --- global.transformer_data: ' .. serpent.block(global.transformer_data))
 end
 
 function playerOrArmorChanged(player_index)
---log ('playerOrArmorChanged --- START --- global.transformer_data: ' .. serpent.block(global.transformer_data))
+log ('playerOrArmorChanged --- START --- global.transformer_data: ' .. serpent.block(global.transformer_data))
 	local player = game.players[player_index]
 	if player.character ~= nil then
 		-- Search table for previously equipped armor and remove it from the table
@@ -767,7 +787,7 @@ function playerOrArmorChanged(player_index)
 				end
 			end
 		end
---log ('playerOrArmorChanged --- POST REMOVAL --- global.transformer_data: ' .. serpent.block(global.transformer_data))
+log ('playerOrArmorChanged --- POST REMOVAL --- global.transformer_data: ' .. serpent.block(global.transformer_data))
 
 		local grid = player.character.grid
 		if grid ~= nil then
@@ -791,13 +811,13 @@ function playerOrArmorChanged(player_index)
 
 		end
 	end
---log ('playerOrArmorChanged --- END --- global.transformer_data: ' .. serpent.block(global.transformer_data))
+log ('playerOrArmorChanged --- END --- global.transformer_data: ' .. serpent.block(global.transformer_data))
 end
 
 function entityTeleported(entity)
---log ('entityTeleported --- PRE REMOVAL --- global.transformer_data: ' .. serpent.block(global.transformer_data))
+log ('entityTeleported --- PRE REMOVAL --- global.transformer_data: ' .. serpent.block(global.transformer_data))
 	entity_removed(entity)
---log ('entityTeleported --- POST REMOVAL --- global.transformer_data: ' .. serpent.block(global.transformer_data))
+log ('entityTeleported --- POST REMOVAL --- global.transformer_data: ' .. serpent.block(global.transformer_data))
 	new_vehicle_placed(entity)
---log ('entityTeleported --- END --- global.transformer_data: ' .. serpent.block(global.transformer_data))
+log ('entityTeleported --- END --- global.transformer_data: ' .. serpent.block(global.transformer_data))
 end

--- a/PersonalTransformer2/control.lua
+++ b/PersonalTransformer2/control.lua
@@ -14,7 +14,7 @@ local mk3_draw = settings.startup["personal-transformer-mk3-flow-limit"].value *
 --local mk2_draw = 1000000
 --local mk3_draw = 4000000
 
--- grid_owner_type can be "player", "entity", "item"
+-- grid_owner_type can be "player" or "entity"
 
 local personal_transformer_mk1_name = "personal-transformer-equipment"
 local personal_transformer_mk2_name = "personal-transformer-mk2-equipment"
@@ -110,7 +110,7 @@ script.on_configuration_changed(
 script.on_event(defines.events.on_equipment_inserted,
 	function(event)
 -- CHARACTER CODE
-		log ('on_equipment_inserted start --- ')
+--		log ('on_equipment_inserted start --- ')
 		local grid_id = event.grid.unique_id
 		local player = isPlayerOwnerOfGrid(grid_id)
 		
@@ -123,13 +123,13 @@ script.on_event(defines.events.on_equipment_inserted,
 		if not isVehicleGridAllowed then
 			return
 		end
-log ('on_equipment_inserted vehicle grids allowed --- ')
+--log ('on_equipment_inserted vehicle grids allowed --- ')
 		local valid_vehicle = global.grid_vehicles[grid_id] -- and global.grid_vehicles[grid_id].entity
-log ('on_equipment_inserted vehicle grid_id --- ' .. serpent.block(grid_id))
-log ('on_equipment_inserted grid_vehicles --- ' .. serpent.block(global.grid_vehicles))
-log ('on_equipment_inserted vehicle --- ' .. serpent.block(valid_vehicle))
+--log ('on_equipment_inserted vehicle grid_id --- ' .. serpent.block(grid_id))
+--log ('on_equipment_inserted grid_vehicles --- ' .. serpent.block(global.grid_vehicles))
+--log ('on_equipment_inserted vehicle --- ' .. serpent.block(valid_vehicle))
 		if valid_vehicle and valid_vehicle.valid then
-log ('on_equipment_inserted valid vehicle --- ')
+--log ('on_equipment_inserted valid vehicle --- ')
 			equipmentInserted(valid_vehicle, grid_id, event.equipment.name, "entity")
 		end
 	end
@@ -185,7 +185,7 @@ script.on_event(defines.events.on_built_entity,
 
 script.on_event(defines.events.on_robot_built_entity, 
 	function(event)
-log ('on_robot_built_entity --- ')
+--log ('on_robot_built_entity --- ')
 		new_vehicle_placed_event_wrapper(event)
 	end
 	-- {LuaPlayerBuiltEntityEventFilters = {"vehicle"}} -- incorrect way
@@ -195,18 +195,8 @@ log ('on_robot_built_entity --- ')
 
 script.on_event(defines.events.on_entity_cloned, 
 	function(event)
-		log ('on_entity_cloned start --- ')
+--		log ('on_entity_cloned start --- ')
 		new_vehicle_placed(event.destination)
---[[
-		if event.source.grid then
-			local grid_id = event.source.grid.unique_id
-				for index, et in ipairs (global.transformer_data[grid_id].grid_transformer_entities) do
-					local entity = table.remove(global.transformer_data[grid_id].grid_transformer_entities, index)
-					entity.destroy()
-					entity = nil
-				end
-		end
---]]		
 		purgeOrphanedEntities()		
 	end
 	-- {LuaPlayerBuiltEntityEventFilters = {"vehicle"}} -- incorrect way
@@ -216,7 +206,7 @@ script.on_event(defines.events.on_entity_cloned,
 
 script.on_event(defines.events.script_raised_built, 
 	function(event)
-log ('script_raised_built --- ')
+--log ('script_raised_built --- ')
 		new_vehicle_placed(event.entity)
 	end
 	-- {LuaPlayerBuiltEntityEventFilters = {"vehicle"}} -- incorrect way
@@ -226,7 +216,7 @@ log ('script_raised_built --- ')
 
 script.on_event(defines.events.script_raised_revive, 
 	function(event)
-log ('script_raised_revive --- ')
+--log ('script_raised_revive --- ')
 		new_vehicle_placed(event.entity)
 	end
 	-- {LuaPlayerBuiltEntityEventFilters = {"vehicle"}} -- incorrect way
@@ -236,7 +226,7 @@ log ('script_raised_revive --- ')
 
 script.on_event(defines.events.on_player_mined_entity, 
 	function(event)
-		log ('on_player_mined_entity start --- ')
+--		log ('on_player_mined_entity start --- ')
 		entity_removed(event.entity)
 	end
 	-- {LuaPlayerBuiltEntityEventFilters = {"vehicle"}} -- incorrect way
@@ -246,7 +236,7 @@ script.on_event(defines.events.on_player_mined_entity,
 
 script.on_event(defines.events.on_robot_mined_entity, 
 	function(event)
-		log ('on_robot_mined_entity start --- ')
+--		log ('on_robot_mined_entity start --- ')
 		entity_removed(event.entity)
 	end
 	-- {LuaPlayerBuiltEntityEventFilters = {"vehicle"}} -- incorrect way
@@ -257,13 +247,13 @@ script.on_event(defines.events.on_robot_mined_entity,
 script.on_event(defines.events.on_entity_destroyed, 
 	function(event)
 		-- entity_removed(event.entity)
-	log ('on_entity_destroyed --- ')
+--	log ('on_entity_destroyed --- ')
 	end
 )
 
 script.on_event(defines.events.on_entity_died, 
 	function(event)
-		log ('on_entity_died start --- ')
+--		log ('on_entity_died start --- ')
 		entity_removed(event.entity)
 --		log ('on_entity_died end --- ')
 	end
@@ -275,7 +265,7 @@ script.on_event(defines.events.on_entity_died,
 
 script.on_event(defines.events.script_raised_destroy, 
 	function(event)
-		log ('script_raised_destroy start --- ')
+--		log ('script_raised_destroy start --- ')
 		entity_removed(event.entity)
 --		log ('script_raised_destroy end --- ')
 	end
@@ -327,10 +317,6 @@ script.on_event(defines.events.on_lua_shortcut,
 			elseif event.prototype_name == 'toggle-equipment-transformer-output' then
 				player.set_shortcut_toggled('toggle-equipment-transformer-output', not player.is_shortcut_toggled('toggle-equipment-transformer-output'))
 			end
-			-- NOTE put code here to remove and re-add entities
---			if not player.is_shortcut_toggled('toggle-equipment-transformer-input') and not player.is_shortcut_toggled('toggle-equipment-transformer-output') then
---				playerOrArmorChanged(event.player_index)
---			end
 		end
 	end
 )
@@ -580,21 +566,21 @@ function insert_entity(equipment_name, grid_owner, grid_id)
 				force = grid_owner.force
 			}
 		table.insert(global.transformer_data[grid_id].grid_transformer_entities, output_entity)
-log ('insert_entity end --- ')
-log ('insert_entity --- input_entity.name: ' .. serpent.block(input_entity.name))
-log ('insert_entity --- input_entity.unit_number: ' .. serpent.block(input_entity.unit_number))
+--log ('insert_entity end --- ')
+--log ('insert_entity --- input_entity.name: ' .. serpent.block(input_entity.name))
+--log ('insert_entity --- input_entity.unit_number: ' .. serpent.block(input_entity.unit_number))
 --log ('insert_entity --- input_entity.position: ' .. serpent.block(input_entity.position))
-log ('insert_entity --- output_entity.name: ' .. serpent.block(output_entity.name))
-log ('insert_entity --- output_entity.unit_number: ' .. serpent.block(output_entity.unit_number))
+--log ('insert_entity --- output_entity.name: ' .. serpent.block(output_entity.name))
+--log ('insert_entity --- output_entity.unit_number: ' .. serpent.block(output_entity.unit_number))
 --log ('insert_entity --- output_entity.position: ' .. serpent.block(output_entity.position))
-listCurrentAndAllPTEntities()
+--listCurrentAndAllPTEntities()
 	end
 end
 
 function remove_entity(equipment_name, grid_id)
 	if is_personal_transformer_name_match(equipment_name) then
 
-listCurrentAndAllPTEntities()
+--listCurrentAndAllPTEntities()
 	
 		local entity_input_name
 		local entity_output_name
@@ -621,8 +607,8 @@ listCurrentAndAllPTEntities()
 --			local entity = global.transformer_data[grid_id].grid_transformer_entities[index]
 --log ('remove_entity --- index: ' .. serpent.block(index))
 --log ('remove_entity --- entity: ' .. serpent.block(entity))
-log ('remove_entity --- entity.name: ' .. serpent.block(entity.name))
-log ('remove_entity --- entity.unit_number: ' .. serpent.block(entity.unit_number))
+--log ('remove_entity --- entity.name: ' .. serpent.block(entity.name))
+--log ('remove_entity --- entity.unit_number: ' .. serpent.block(entity.unit_number))
 			if (entity.name == entity_input_name) then
 				local entity = table.remove(global.transformer_data[grid_id].grid_transformer_entities, index)
 --				log ('remove_entity --- entity: ' .. serpent.block(entity))
@@ -638,8 +624,8 @@ log ('remove_entity --- entity.unit_number: ' .. serpent.block(entity.unit_numbe
 --log ('remove_entity --- index: ' .. serpent.block(index))
 --log ('remove_entity --- entity: ' .. serpent.block(entity))
 --log ('remove_entity --- entity.name: ' .. serpent.block(entity.name))
-log ('remove_entity --- entity.name: ' .. serpent.block(entity.name))
-log ('remove_entity --- entity.unit_number: ' .. serpent.block(entity.unit_number))
+--log ('remove_entity --- entity.name: ' .. serpent.block(entity.name))
+--log ('remove_entity --- entity.unit_number: ' .. serpent.block(entity.unit_number))
 			if (entity.name == entity_output_name) then
 				local entity = table.remove(global.transformer_data[grid_id].grid_transformer_entities, index)
 --				log ('remove_entity --- entity: ' .. serpent.block(entity))
@@ -651,22 +637,10 @@ log ('remove_entity --- entity.unit_number: ' .. serpent.block(entity.unit_numbe
 		end
 --		log ('remove_entity --- global.transformer_data post removal: ' .. serpent.block(global.transformer_data))
 	end
-	log ('remove_entity --- abandoned entities: ')
-	for _, surface in pairs(game.surfaces) do 
-		for _, ent in pairs (surface.find_entities_filtered({name={"personal-transformer-input-entity", "personal-transformer-output-entity", "personal-transformer-mk2-input-entity", "personal-transformer-mk2-output-entity", "personal-transformer-mk3-input-entity", "personal-transformer-mk3-output-entity"}})) do 
-			log ('remove_entity --- entity.name: ' .. serpent.block(ent.name))
-			log ('remove_entity --- entity.unit_number: ' .. serpent.block(ent.unit_number))
-		end 
-	end
-	log ('remove_entity --- listed entities: ')
-	for gd_id, transformer_data_values in pairs(global.transformer_data) do
-		for index, et in ipairs (transformer_data_values.grid_transformer_entities) do
-			log ('remove_entity --- entity.name: ' .. serpent.block(et.name))
-			log ('remove_entity --- entity.unit_number: ' .. serpent.block(et.unit_number))
-		end
-	end
-log ('remove_entity --- grid_id: ' .. serpent.block(grid_id))
-log ('remove_entity --- END global.transformer_data: ' .. serpent.block(global.transformer_data))
+--listCurrentAndAllPTEntities()
+
+--log ('remove_entity --- grid_id: ' .. serpent.block(grid_id))
+--log ('remove_entity --- END global.transformer_data: ' .. serpent.block(global.transformer_data))
 end
 
 function new_vehicle_placed_event_wrapper(event)
@@ -719,7 +693,7 @@ function entity_removed(entity)
 --	log ('entity_removed start --- global.transformer_data: ' .. serpent.block(global.transformer_data))
 --	log ('entity_removed start --- global.grid_vehicles: ' .. serpent.block(global.grid_vehicles))
 --	log ('entity_removed start --- entity.unit_number: ' .. serpent.block(entity.unit_number))
-	log ('entity_removed start --- entity.type: ' .. serpent.block(entity.type))
+--	log ('entity_removed start --- entity.type: ' .. serpent.block(entity.type))
 	
 --	log ('entity_removed start --- vehicle_grid:4200: unit_number ' .. serpent.block(global.grid_vehicles[4200].unit_number))
 	if not isVehicleGridAllowed then
@@ -728,10 +702,10 @@ function entity_removed(entity)
 	local grid_id
 	for index, vehicle_entity in pairs (global.grid_vehicles) do 
 		-- See: https://lua-api.factorio.com/latest/classes/LuaEntity.html#unit_number
-log ('entity_removed --- index ' .. serpent.block(index))
+--log ('entity_removed --- index ' .. serpent.block(index))
 --		if entity.unit_number == vehicle_entity.unit_number then
 		if entity == vehicle_entity then
-			log ('entity_removed --- entities match')
+--			log ('entity_removed --- entities match')
 			grid_id = index
 			global.grid_vehicles[grid_id] = nil
 			break
@@ -739,24 +713,25 @@ log ('entity_removed --- index ' .. serpent.block(index))
 	end
 	
 	if not grid_id then
-		log ('entity_removed --- grid_id is null')
-		log ('entity_removed end --- global.transformer_data: ' .. serpent.block(global.transformer_data))
-		log ('entity_removed end --- global.grid_vehicles: ' .. serpent.block(global.grid_vehicles))
+--		log ('entity_removed --- grid_id is null')
+--		log ('entity_removed end --- global.transformer_data: ' .. serpent.block(global.transformer_data))
+--		log ('entity_removed end --- global.grid_vehicles: ' .. serpent.block(global.grid_vehicles))
 		return
 	end
 
-log ('entity_removed --- grid_id: ' .. serpent.block(grid_id))
+--log ('entity_removed --- grid_id: ' .. serpent.block(grid_id))
 	local transformer_data_values = global.transformer_data[grid_id]
+--log ('entity_removed --- global.transformer_data[grid_id]: ' .. serpent.block(transformer_data_values))
 
-	if transformer_data_values.grid_owner_type == "entity" and transformer_data_values.grid_owner_id == grid_id then
+	if transformer_data_values and transformer_data_values.grid_owner_type == "entity" and transformer_data_values.grid_owner_id == grid_id then
 		for count_key, count_value in pairs(transformer_data_values.transformer_count) do
 			if count_value > 0 then
 				equipmentRemoved(grid_id, count_key, count_value)
 			end
 		end
 	end
-	log ('entity_removed end --- global.transformer_data: ' .. serpent.block(global.transformer_data))
-	log ('entity_removed end --- global.grid_vehicles: ' .. serpent.block(global.grid_vehicles))
+--	log ('entity_removed end --- global.transformer_data: ' .. serpent.block(global.transformer_data))
+--	log ('entity_removed end --- global.grid_vehicles: ' .. serpent.block(global.grid_vehicles))
 end
 
 function isPlayerOwnerOfGrid(grid_id)
@@ -781,7 +756,7 @@ function teleportEntitiesToPlayerPosition(player_pos, grid_transformer_entities)
 end
 
 function equipmentInserted(player, grid_id, equipment_name, grid_owner_type)
-	log ('equipmentInserted before --- global.transformer_data: ' .. serpent.block(global.transformer_data))
+--	log ('equipmentInserted before --- global.transformer_data: ' .. serpent.block(global.transformer_data))
 	if is_personal_transformer_name_match(equipment_name) then
 		if not global.transformer_data[grid_id] then 
 			global.transformer_data[grid_id] = {}
@@ -809,16 +784,16 @@ function equipmentInserted(player, grid_id, equipment_name, grid_owner_type)
 		end
 		global.transformer_data[grid_id].max_grid_draw = global.transformer_data[grid_id].max_grid_draw + transformer_draw[equipment_name]
 		global.transformer_data[grid_id].buffer = global.transformer_data[grid_id].max_grid_draw / 10
-	log ('equipmentInserted after --- global.transformer_data after: ' .. serpent.block(global.transformer_data))
+--	log ('equipmentInserted after --- global.transformer_data after: ' .. serpent.block(global.transformer_data))
 	end
 end
 
 function equipmentRemoved(grid_id, equipment_name, count)
 	if is_personal_transformer_name_match(equipment_name) then
-		log ('on_equipment_removed before --- global.transformer_data: ' .. serpent.block(global.transformer_data))
-		log ('on_equipment_removed --- grid_id: ' .. serpent.block(grid_id))
-		log ('on_equipment_removed --- count: ' .. serpent.block(count))
-		log ('on_equipment_removed --- equipment_name: ' .. serpent.block(equipment_name))
+--		log ('on_equipment_removed before --- global.transformer_data: ' .. serpent.block(global.transformer_data))
+--		log ('on_equipment_removed --- grid_id: ' .. serpent.block(grid_id))
+--		log ('on_equipment_removed --- count: ' .. serpent.block(count))
+--		log ('on_equipment_removed --- equipment_name: ' .. serpent.block(equipment_name))
 		for i = 1, count do 
 			remove_entity(equipment_name, grid_id)
 		end
@@ -831,7 +806,7 @@ function equipmentRemoved(grid_id, equipment_name, count)
 		local total_count = global.transformer_data[grid_id].transformer_count[personal_transformer_mk1_name] + global.transformer_data[grid_id].transformer_count[personal_transformer_mk2_name] + global.transformer_data[grid_id].transformer_count[personal_transformer_mk3_name]
 
 		if total_count == 0 then
-			log ('If no more transformers --- Clear out object')
+--			log ('If no more transformers --- Clear out object')
 			global.transformer_data[grid_id].transformer_count = nil
 			global.transformer_data[grid_id].grid_owner_id = nil
 			global.transformer_data[grid_id].grid_owner_type = nil
@@ -840,8 +815,8 @@ function equipmentRemoved(grid_id, equipment_name, count)
 			global.transformer_data[grid_id] = nil
 		end
 	end
-	log ('on_equipment_removed after --- grid_id: ' .. serpent.block(grid_id))
-	log ('on_equipment_removed after --- global.transformer_data: ' .. serpent.block(global.transformer_data))
+--	log ('on_equipment_removed after --- grid_id: ' .. serpent.block(grid_id))
+--	log ('on_equipment_removed after --- global.transformer_data: ' .. serpent.block(global.transformer_data))
 end
 
 function playerOrArmorChanged(player_index)

--- a/PersonalTransformer2/control.lua
+++ b/PersonalTransformer2/control.lua
@@ -309,7 +309,7 @@ script.on_event(defines.events.on_player_driving_changed_state,
 
 script.on_event(defines.events.on_player_cheat_mode_enabled, 
 	function(event)
-		log ('on_player_cheat_mode_enabled start --- ')
+--		log ('on_player_cheat_mode_enabled start --- ')
 	end
 )
 

--- a/PersonalTransformer2/control.lua
+++ b/PersonalTransformer2/control.lua
@@ -5,9 +5,10 @@ local my_types = {"car", "spider-vehicle", "locomotive", "cargo-wagon", "fluid-w
 -- Lower values are more UPS intensive but have finer updates, while higher values are less UPS intensive but have coarser updates.
 local tickdelay = settings.global["personal-transformer2-tick-delay"].value
 
-local mk1_draw = 200000
-local mk2_draw = 1000000
-local mk3_draw = 4000000
+
+local mk1_draw = settings.startup["personal-transformer-mk1-flow-limit"].value
+local mk2_draw = settings.startup["personal-transformer-mk2-flow-limit"].value
+local mk3_draw = settings.startup["personal-transformer-mk3-flow-limit"].value
 
 -- grid_owner_type can be "player", "entity", "item"
 

--- a/PersonalTransformer2/data-updates.lua
+++ b/PersonalTransformer2/data-updates.lua
@@ -53,3 +53,29 @@ data:extend(
   }
 }
 )
+
+-- Mk1
+data.raw["battery-equipment"]["personal-transformer-equipment"].energy_source.input_flow_limit = settings.startup["personal-transformer-mk1-flow-limit"].value .. "kW"
+data.raw["battery-equipment"]["personal-transformer-equipment"].energy_source.output_flow_limit = settings.startup["personal-transformer-mk1-flow-limit"].value .. "kW"
+data.raw["battery-equipment"]["personal-transformer-equipment"].energy_source.buffer_capacity = settings.startup["personal-transformer-mk1-flow-limit"].value/10 .. "kJ"
+data.raw["electric-energy-interface"]["personal-transformer-input-entity"].energy_source.input_flow_limit = settings.startup["personal-transformer-mk1-flow-limit"].value .. "kW"
+data.raw["electric-energy-interface"]["personal-transformer-input-entity"].energy_source.buffer_capacity = settings.startup["personal-transformer-mk1-flow-limit"].value/10 .. "kJ"
+data.raw["accumulator"]["personal-transformer-output-entity"].energy_source.output_flow_limit = settings.startup["personal-transformer-mk1-flow-limit"].value .. "kW"
+data.raw["accumulator"]["personal-transformer-output-entity"].energy_source.buffer_capacity = settings.startup["personal-transformer-mk1-flow-limit"].value/10 .. "kJ"
+-- Mk2
+data.raw["battery-equipment"]["personal-transformer-mk2-equipment"].energy_source.input_flow_limit = settings.startup["personal-transformer-mk2-flow-limit"].value .. "kW"
+data.raw["battery-equipment"]["personal-transformer-mk2-equipment"].energy_source.output_flow_limit = settings.startup["personal-transformer-mk2-flow-limit"].value .. "kW"
+data.raw["battery-equipment"]["personal-transformer-mk2-equipment"].energy_source.buffer_capacity = settings.startup["personal-transformer-mk2-flow-limit"].value/10 .. "kJ"
+data.raw["electric-energy-interface"]["personal-transformer-mk2-input-entity"].energy_source.input_flow_limit = settings.startup["personal-transformer-mk2-flow-limit"].value .. "kW"
+data.raw["electric-energy-interface"]["personal-transformer-mk2-input-entity"].energy_source.buffer_capacity = settings.startup["personal-transformer-mk2-flow-limit"].value/10 .. "kJ"
+data.raw["accumulator"]["personal-transformer-mk2-output-entity"].energy_source.output_flow_limit = settings.startup["personal-transformer-mk2-flow-limit"].value .. "kW"
+data.raw["accumulator"]["personal-transformer-mk2-output-entity"].energy_source.buffer_capacity = settings.startup["personal-transformer-mk2-flow-limit"].value/10 .. "kJ"
+-- Mk3
+data.raw["battery-equipment"]["personal-transformer-mk3-equipment"].energy_source.input_flow_limit = settings.startup["personal-transformer-mk3-flow-limit"].value .. "kW"
+data.raw["battery-equipment"]["personal-transformer-mk3-equipment"].energy_source.output_flow_limit = settings.startup["personal-transformer-mk3-flow-limit"].value .. "kW"
+data.raw["battery-equipment"]["personal-transformer-mk3-equipment"].energy_source.buffer_capacity = settings.startup["personal-transformer-mk3-flow-limit"].value/10 .. "kJ"
+data.raw["electric-energy-interface"]["personal-transformer-mk3-input-entity"].energy_source.input_flow_limit = settings.startup["personal-transformer-mk3-flow-limit"].value .. "kW"
+data.raw["electric-energy-interface"]["personal-transformer-mk3-input-entity"].energy_source.buffer_capacity = settings.startup["personal-transformer-mk3-flow-limit"].value/10 .. "kJ"
+data.raw["accumulator"]["personal-transformer-mk3-output-entity"].energy_source.output_flow_limit = settings.startup["personal-transformer-mk3-flow-limit"].value .. "kW"
+data.raw["accumulator"]["personal-transformer-mk3-output-entity"].energy_source.buffer_capacity = settings.startup["personal-transformer-mk3-flow-limit"].value/10 .. "kJ"
+

--- a/PersonalTransformer2/data.lua
+++ b/PersonalTransformer2/data.lua
@@ -4,4 +4,3 @@ require('prototypes.item')
 require('prototypes.recipe')
 require('prototypes.shortcuts')
 require('prototypes.technology')
-

--- a/PersonalTransformer2/info.json
+++ b/PersonalTransformer2/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "PersonalTransformer2",
-	"version": "0.1.18",
+	"version": "1.0.0",
 	"title": "Personal Transformer2",
 	"author": "Pikachar",
 	

--- a/PersonalTransformer2/locale/en/locale.cfg
+++ b/PersonalTransformer2/locale/en/locale.cfg
@@ -35,10 +35,16 @@ personal-transformer-mk2-equipment=Allows for improved charging from the power g
 personal-transformer-mk3-equipment=Allows the player to cause blackouts at outposts. Charges at up to 4 MW.
 
 [mod-setting-name]
-personal-transformer2-allow-non-armor=Allow Personal Transformer in non-armor grids (BETA)
+personal-transformer2-allow-non-armor=Allow Personal Transformer in non-armor grids
 personal-transformer2-tick-delay=Set Tick Delay
+personal-transformer-mk1-flow-limit=Personal Transformer Mk1 Input Value
+personal-transformer-mk2-flow-limit=Personal Transformer Mk2 Input Value
+personal-transformer-mk3-flow-limit=Personal Transformer Mk3 Input Value
 
 [mod-setting-description]
 personal-transformer2-allow-non-armor=Allow Personal Transformer to be placed in non-armor grids.
 personal-transformer2-tick-delay=This is a delay constant for controlling how often the transformer script runs. The mod will behave reasonably for any value from 1 to 6. Lower values are more UPS intensive but have finer updates, while higher values are less UPS intensive but have coarser updates.
+personal-transformer-mk1-flow-limit=Sets the maximum input flow rate of the Personal Transformer Mk1 in kW
+personal-transformer-mk2-flow-limit=Sets the maximum input flow rate of the Personal Transformer Mk2 in kW
+personal-transformer-mk3-flow-limit=Sets the maximum input flow rate of the Personal Transformer Mk3 in kW
 

--- a/PersonalTransformer2/settings.lua
+++ b/PersonalTransformer2/settings.lua
@@ -17,5 +17,32 @@ data:extend
     default_value = 1,
     per_user = false,
     order = "a2"
+  },
+  {
+    type = "double-setting",
+    name = "personal-transformer-mk1-flow-limit",
+    setting_type = "startup",
+	minimum_value = 0,
+    default_value = 200,
+    per_user = false,
+    order = "a2"
+  },
+  {
+    type = "double-setting",
+    name = "personal-transformer-mk2-flow-limit",
+    setting_type = "startup",
+	minimum_value = 0,
+    default_value = 1000,
+    per_user = false,
+    order = "a2"
+  },
+  {
+    type = "double-setting",
+    name = "personal-transformer-mk3-flow-limit",
+    setting_type = "startup",
+	minimum_value = 0,
+    default_value = 4000,
+    per_user = false,
+    order = "a2"
   }
 }


### PR DESCRIPTION
Version: 1.0.0
  Features:
    - Added settings to allow for the configuration of the flow rate of each transformer.
	- Removed Beta tag from 'Allow Personal Transformer in non-armor Grids' setting.
    - Added ability to enable/disable the ability to use the shortcuts in most scenarios.
  Bugfix:
    - Fixed several crashes introduced in 0.1.18 despite the fact I swear I tested those scenarios
	- Fixed case where when a train was cloned it would leave duplicates of the invisible transformers lying around.
  Note:
    - Biggest performance hits are on having a large amount of other gear in your grid. If you can think of a way to improve this, please let me know.
