### PR TITLE
Quality fix

### DIFF
--- a/PersonalTransformer2/changelog.txt
+++ b/PersonalTransformer2/changelog.txt
@@ -2,6 +2,11 @@
 Version: 1.0.3
   Bugfix:
     - Fixed issue where quality was not accounted for.
+  Current Bugs:
+    - Putting on armor or placing a vehicle with Personal Transformers in them will upgrade all Personal Transformers to Legendary Quality.
+    - To revert to the actual quality, take out and replace the Personal Transformers in the armor/vehicle.
+    - Currently quality is not accounted for when counting equipment in grids. And I'm hoping for an update to the API as opposed to rewriting a large portion.
+    - Request for API update: https://forums.factorio.com/viewtopic.php?f=28&t=118603
 
 ---------------------------------------------------------------------------------------------------
 Version: 1.0.2

--- a/PersonalTransformer2/changelog.txt
+++ b/PersonalTransformer2/changelog.txt
@@ -1,11 +1,16 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.0.3
+  Bugfix:
+    - Fixed issue where quality was not accounted for.
+
+---------------------------------------------------------------------------------------------------
 Version: 1.0.2
   Bugfix:
     - Fixed crash involving changes to how equipment energy sources are referenced.
   Note:
     - Quality is currently not taken into account with power transfer.
     - Higher quality Personal Transformers do not get increased gains.
-	
+
 ---------------------------------------------------------------------------------------------------
 Version: 1.0.1
   Features:
@@ -13,7 +18,7 @@ Version: 1.0.1
     - Works with Quality enabled.
     - Works with Elevated Rails enabled.
     - Works with Space Age enabled.
-	
+
 ---------------------------------------------------------------------------------------------------
 Version: 1.0.0
   Features:
@@ -27,7 +32,7 @@ Version: 1.0.0
   Note:
     - Remove all transformers from grids upon updating.
     - Biggest performance hits are on having a large amount of other gear in your grid. If you can think of a way to improve this, please let me know.
-	
+
 ---------------------------------------------------------------------------------------------------
 Version: 0.1.18
   Optimizations:

--- a/PersonalTransformer2/control.lua
+++ b/PersonalTransformer2/control.lua
@@ -117,7 +117,8 @@ script.on_event(defines.events.on_equipment_inserted,
 		local player = isPlayerOwnerOfGrid(grid_id)
 		
 		if player ~= nil then
-			equipmentInserted(player, grid_id, event.equipment.name, "player")
+log ('on_equipment_inserted --- event.equipment.quality.name = '.. serpent.block(event.equipment.quality.name))
+			equipmentInserted(player, grid_id, event.equipment.name, "player", event.equipment.quality.name)
 			return
 		end
 
@@ -132,7 +133,7 @@ script.on_event(defines.events.on_equipment_inserted,
 --log ('on_equipment_inserted vehicle --- ' .. serpent.block(valid_vehicle))
 		if valid_vehicle and valid_vehicle.valid then
 --log ('on_equipment_inserted valid vehicle --- ')
-			equipmentInserted(valid_vehicle, grid_id, event.equipment.name, "entity")
+			equipmentInserted(valid_vehicle, grid_id, event.equipment.name, "entity", event.equipment.quality.name)
 		end
 	end
 )
@@ -474,8 +475,6 @@ function update_vehicle_transformer(tickdelay, transformer_data)
 				-- perform math
 					for _, v in pairs(grid.equipment) do
 						if v.prototype.energy_source ~= nil and v.prototype.energy_source.valid then
-log ('update_vehicle_transformer --- v.prototype.energy_source: ' .. serpent.block(v.prototype.energy_source))
-log ('update_vehicle_transformer --- v.prototype.energy_source.valid: ' .. serpent.block(v.prototype.energy_source.valid))
 							-- if energy source calculate max_draw_in/out from equipment with flow limit
 							-- ie, what's the flow rate of the generators/batteries
 							-- toggle off appropriate draw if toggle is off
@@ -550,7 +549,7 @@ function is_personal_transformer_name_match(name)
 	return name == personal_transformer_mk1_name or name == personal_transformer_mk2_name or name == personal_transformer_mk3_name
 end
 
-function insert_entity(equipment_name, grid_owner, grid_id)
+function insert_entity(equipment_name, grid_owner, grid_id, quality_name)
 	if is_personal_transformer_name_match(equipment_name) then
 		local entity_input_name
 		local entity_output_name
@@ -568,15 +567,16 @@ function insert_entity(equipment_name, grid_owner, grid_id)
 			{
 				name = entity_input_name,
 				position = grid_owner.position,
-				force = grid_owner.force
+				force = grid_owner.force,
+				quality = quality_name
 			}
 		table.insert(storage.transformer_data[grid_id].grid_transformer_entities, input_entity)
 		local output_entity = grid_owner.surface.create_entity
 			{
 				name = entity_output_name,
 				position = grid_owner.position,
-				force = grid_owner.force
---				quality = 
+				force = grid_owner.force,
+				quality = quality_name
 			}
 		table.insert(storage.transformer_data[grid_id].grid_transformer_entities, output_entity)
 --log ('insert_entity end --- ')
@@ -686,17 +686,17 @@ function new_vehicle_placed(entity)
 		local mk3_count = grid.count(personal_transformer_mk3_name)
 		if mk1_count > 0 then
 			for i = 1, mk1_count do
-				equipmentInserted(vehicle, grid_id, personal_transformer_mk1_name, "entity")
+				equipmentInserted(vehicle, grid_id, personal_transformer_mk1_name, "entity", "normal")
 			end
 		end
 		if mk2_count > 0 then
 			for i = 1, mk2_count do
-				equipmentInserted(vehicle, grid_id, personal_transformer_mk2_name, "entity")
+				equipmentInserted(vehicle, grid_id, personal_transformer_mk2_name, "entity", "normal")
 			end
 		end
 		if mk3_count > 0 then
 			for i = 1, mk3_count do
-				equipmentInserted(vehicle, grid_id, personal_transformer_mk3_name, "entity")
+				equipmentInserted(vehicle, grid_id, personal_transformer_mk3_name, "entity", "normal")
 			end
 		end
 	end
@@ -770,7 +770,7 @@ function teleportEntitiesToPlayerPosition(player_pos, grid_transformer_entities)
 	end
 end
 
-function equipmentInserted(player, grid_id, equipment_name, grid_owner_type)
+function equipmentInserted(player, grid_id, equipment_name, grid_owner_type, quality_name)
 --	local quality = equipment.equipment_name
 --	log ('equipmentInserted before --- storage.transformer_data: ' .. serpent.block(storage.transformer_data))
 	if is_personal_transformer_name_match(equipment_name) then
@@ -778,7 +778,7 @@ function equipmentInserted(player, grid_id, equipment_name, grid_owner_type)
 			storage.transformer_data[grid_id] = {}
 			storage.transformer_data[grid_id].grid_transformer_entities = {}
 		end
-		insert_entity(equipment_name, player, grid_id)
+		insert_entity(equipment_name, player, grid_id, quality_name)
 
 		if not storage.transformer_data[grid_id].transformer_count then 
 			storage.transformer_data[grid_id].transformer_count = {}
@@ -868,13 +868,13 @@ function playerOrArmorChanged(player_index)
 			local mk3_count = grid.count(personal_transformer_mk3_name)
 
 			for i = 1, mk1_count do
-				equipmentInserted(player, current_grid_id, personal_transformer_mk1_name, "player")
+				equipmentInserted(player, current_grid_id, personal_transformer_mk1_name, "player", "normal")
 			end
 			for i = 1, mk2_count do
-				equipmentInserted(player, current_grid_id, personal_transformer_mk2_name, "player")
+				equipmentInserted(player, current_grid_id, personal_transformer_mk2_name, "player", "normal")
 			end
 			for i = 1, mk3_count do
-				equipmentInserted(player, current_grid_id, personal_transformer_mk3_name, "player")
+				equipmentInserted(player, current_grid_id, personal_transformer_mk3_name, "player", "normal")
 			end
 			
 			if mk1_count + mk2_count + mk3_count > 0 then

--- a/PersonalTransformer2/control.lua
+++ b/PersonalTransformer2/control.lua
@@ -117,7 +117,7 @@ script.on_event(defines.events.on_equipment_inserted,
 		local player = isPlayerOwnerOfGrid(grid_id)
 		
 		if player ~= nil then
-log ('on_equipment_inserted --- event.equipment.quality.name = '.. serpent.block(event.equipment.quality.name))
+--log ('on_equipment_inserted --- event.equipment.quality.name = '.. serpent.block(event.equipment.quality.name))
 			equipmentInserted(player, grid_id, event.equipment.name, "player", event.equipment.quality.name)
 			return
 		end

--- a/PersonalTransformer2/control.lua
+++ b/PersonalTransformer2/control.lua
@@ -686,17 +686,17 @@ function new_vehicle_placed(entity)
 		local mk3_count = grid.count(personal_transformer_mk3_name)
 		if mk1_count > 0 then
 			for i = 1, mk1_count do
-				equipmentInserted(vehicle, grid_id, personal_transformer_mk1_name, "entity", "normal")
+				equipmentInserted(vehicle, grid_id, personal_transformer_mk1_name, "entity", "legendary")
 			end
 		end
 		if mk2_count > 0 then
 			for i = 1, mk2_count do
-				equipmentInserted(vehicle, grid_id, personal_transformer_mk2_name, "entity", "normal")
+				equipmentInserted(vehicle, grid_id, personal_transformer_mk2_name, "entity", "legendary")
 			end
 		end
 		if mk3_count > 0 then
 			for i = 1, mk3_count do
-				equipmentInserted(vehicle, grid_id, personal_transformer_mk3_name, "entity", "normal")
+				equipmentInserted(vehicle, grid_id, personal_transformer_mk3_name, "entity", "legendary")
 			end
 		end
 	end
@@ -868,13 +868,13 @@ function playerOrArmorChanged(player_index)
 			local mk3_count = grid.count(personal_transformer_mk3_name)
 
 			for i = 1, mk1_count do
-				equipmentInserted(player, current_grid_id, personal_transformer_mk1_name, "player", "normal")
+				equipmentInserted(player, current_grid_id, personal_transformer_mk1_name, "player", "legendary")
 			end
 			for i = 1, mk2_count do
-				equipmentInserted(player, current_grid_id, personal_transformer_mk2_name, "player", "normal")
+				equipmentInserted(player, current_grid_id, personal_transformer_mk2_name, "player", "legendary")
 			end
 			for i = 1, mk3_count do
-				equipmentInserted(player, current_grid_id, personal_transformer_mk3_name, "player", "normal")
+				equipmentInserted(player, current_grid_id, personal_transformer_mk3_name, "player", "legendary")
 			end
 			
 			if mk1_count + mk2_count + mk3_count > 0 then

--- a/PersonalTransformer2/info.json
+++ b/PersonalTransformer2/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "PersonalTransformer2",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"title": "Personal Transformer2",
 	"author": "Pikachar",
 	

--- a/PersonalTransformer2/locale/en/locale.cfg
+++ b/PersonalTransformer2/locale/en/locale.cfg
@@ -3,12 +3,12 @@ personal-transformer-toggle-input=Toggle personal transformer input
 personal-transformer-toggle-output=Toggle personal transformer output
 
 [entity-name]
-personal-transformer-input-entity=Personal transformer
-personal-transformer-output-entity=Personal transformer
-personal-transformer-mk2-input-entity=Personal transformer MK2
-personal-transformer-mk2-output-entity=Personal transformer MK2
-personal-transformer-mk3-input-entity=Personal transformer MK3
-personal-transformer-mk3-output-entity=Personal transformer MK3
+personal-transformer-input-entity=Personal transformer IN
+personal-transformer-output-entity=Personal transformer OUT
+personal-transformer-mk2-input-entity=Personal transformer MK2 IN
+personal-transformer-mk2-output-entity=Personal transformer MK2 OUT
+personal-transformer-mk3-input-entity=Personal transformer MK3 IN
+personal-transformer-mk3-output-entity=Personal transformer MK3 OUT
 
 [equipment-name]
 personal-transformer-equipment=Personal transformer

--- a/PersonalTransformer2/locale/en/locale.cfg
+++ b/PersonalTransformer2/locale/en/locale.cfg
@@ -3,12 +3,12 @@ personal-transformer-toggle-input=Toggle personal transformer input
 personal-transformer-toggle-output=Toggle personal transformer output
 
 [entity-name]
-personal-transformer-input-entity=Personal transformer IN
-personal-transformer-output-entity=Personal transformer OUT
-personal-transformer-mk2-input-entity=Personal transformer MK2 IN
-personal-transformer-mk2-output-entity=Personal transformer MK2 OUT
-personal-transformer-mk3-input-entity=Personal transformer MK3 IN
-personal-transformer-mk3-output-entity=Personal transformer MK3 OUT
+personal-transformer-input-entity=Personal transformer
+personal-transformer-output-entity=Personal transformer
+personal-transformer-mk2-input-entity=Personal transformer MK2
+personal-transformer-mk2-output-entity=Personal transformer MK2
+personal-transformer-mk3-input-entity=Personal transformer MK3
+personal-transformer-mk3-output-entity=Personal transformer MK3
 
 [equipment-name]
 personal-transformer-equipment=Personal transformer

--- a/PersonalTransformer2/prototypes/entity.lua
+++ b/PersonalTransformer2/prototypes/entity.lua
@@ -1,14 +1,4 @@
-data:extend{
-	{
-		type = 'electric-energy-interface',
-		name = 'personal-transformer-input-entity',
-		icon = '__base__/graphics/icons/power-armor.png',
-		icon_size = 32,
-		flags = { 'placeable-off-grid', 'not-on-map' },
-		minable = nil,
-		max_health = 500,
-		resistances =
-		{
+local all_resistances = {
 			{
 				type = 'physical',
 				percent = 100
@@ -41,7 +31,18 @@ data:extend{
 				type = 'electric',
 				percent = 100
 			}
-		},
+		}
+
+data:extend{
+	{
+		type = 'electric-energy-interface',
+		name = 'personal-transformer-input-entity',
+		icon = '__base__/graphics/icons/power-armor.png',
+		icon_size = 32,
+		flags = { 'placeable-off-grid', 'not-on-map' },
+		minable = nil,
+		max_health = 500,
+		resistances = all_resistances,
 		collision_box = {{ -0.2, -0.2 }, { 0.2, 0.2 }},
 		selection_box = {{ -0.01, -0.01 }, { 0.01, 0.01 }},
 		collision_mask = {
@@ -79,41 +80,7 @@ data:extend{
 		flags = { 'placeable-off-grid', 'not-on-map' },
 		minable = nil,
 		max_health = 500,
-		resistances =
-		{
-			{
-				type = 'physical',
-				percent = 100
-			},
-			{
-				type = 'impact',
-				percent = 100
-			},
-			{
-				type = 'poison',
-				percent = 100
-			},
-			{
-				type = 'explosion',
-				percent = 100
-			},
-			{
-				type = 'fire',
-				percent = 100
-			},
-			{
-				type = 'laser',
-				percent = 100
-			},
-			{
-				type = 'acid',
-				percent = 100
-			},
-			{
-				type = 'electric',
-				percent = 100
-			}
-		},
+		resistances = all_resistances,
 		collision_box = {{ -0.2, -0.2 }, { 0.2, 0.2 }},
 		selection_box = {{ -0.01, -0.01 }, { 0.01, 0.01 }},
 		collision_mask = {
@@ -153,41 +120,7 @@ data:extend{
 		flags = { 'placeable-off-grid', 'not-on-map' },
 		minable = nil,
 		max_health = 500,
-		resistances =
-		{
-			{
-				type = 'physical',
-				percent = 100
-			},
-			{
-				type = 'impact',
-				percent = 100
-			},
-			{
-				type = 'poison',
-				percent = 100
-			},
-			{
-				type = 'explosion',
-				percent = 100
-			},
-			{
-				type = 'fire',
-				percent = 100
-			},
-			{
-				type = 'laser',
-				percent = 100
-			},
-			{
-				type = 'acid',
-				percent = 100
-			},
-			{
-				type = 'electric',
-				percent = 100
-			}
-		},
+		resistances = all_resistances,
 		collision_box = {{ -0.2, -0.2 }, { 0.2, 0.2 }},
 		selection_box = {{ -0.01, -0.01 }, { 0.01, 0.01 }},
 		collision_mask = {
@@ -225,41 +158,7 @@ data:extend{
 		flags = { 'placeable-off-grid', 'not-on-map' },
 		minable = nil,
 		max_health = 500,
-		resistances =
-		{
-			{
-				type = 'physical',
-				percent = 100
-			},
-			{
-				type = 'impact',
-				percent = 100
-			},
-			{
-				type = 'poison',
-				percent = 100
-			},
-			{
-				type = 'explosion',
-				percent = 100
-			},
-			{
-				type = 'fire',
-				percent = 100
-			},
-			{
-				type = 'laser',
-				percent = 100
-			},
-			{
-				type = 'acid',
-				percent = 100
-			},
-			{
-				type = 'electric',
-				percent = 100
-			}
-		},
+		resistances = all_resistances,
 		collision_box = {{ -0.2, -0.2 }, { 0.2, 0.2 }},
 		selection_box = {{ -0.01, -0.01 }, { 0.01, 0.01 }},
 		collision_mask = {
@@ -299,41 +198,7 @@ data:extend{
 		flags = { 'placeable-off-grid', 'not-on-map' },
 		minable = nil,
 		max_health = 500,
-		resistances =
-		{
-			{
-				type = 'physical',
-				percent = 100
-			},
-			{
-				type = 'impact',
-				percent = 100
-			},
-			{
-				type = 'poison',
-				percent = 100
-			},
-			{
-				type = 'explosion',
-				percent = 100
-			},
-			{
-				type = 'fire',
-				percent = 100
-			},
-			{
-				type = 'laser',
-				percent = 100
-			},
-			{
-				type = 'acid',
-				percent = 100
-			},
-			{
-				type = 'electric',
-				percent = 100
-			}
-		},
+		resistances = all_resistances,
 		collision_box = {{ -0.2, -0.2 }, { 0.2, 0.2 }},
 		selection_box = {{ -0.01, -0.01 }, { 0.01, 0.01 }},
 		collision_mask = {
@@ -371,41 +236,7 @@ data:extend{
 		flags = { 'placeable-off-grid', 'not-on-map' },
 		minable = nil,
 		max_health = 500,
-		resistances =
-		{
-			{
-				type = 'physical',
-				percent = 100
-			},
-			{
-				type = 'impact',
-				percent = 100
-			},
-			{
-				type = 'poison',
-				percent = 100
-			},
-			{
-				type = 'explosion',
-				percent = 100
-			},
-			{
-				type = 'fire',
-				percent = 100
-			},
-			{
-				type = 'laser',
-				percent = 100
-			},
-			{
-				type = 'acid',
-				percent = 100
-			},
-			{
-				type = 'electric',
-				percent = 100
-			}
-		},
+		resistances = all_resistances,
 		collision_box = {{ -0.2, -0.2 }, { 0.2, 0.2 }},
 		selection_box = {{ -0.01, -0.01 }, { 0.01, 0.01 }},
 		collision_mask = {


### PR DESCRIPTION
Version: 1.0.3
  Bugfix:
    - Fixed issue where quality was not accounted for.
  Current Bugs:
    - Putting on armor or placing a vehicle with Personal Transformers in them will upgrade all Personal Transformers to Legendary Quality.
    - To revert to the actual quality, take out and replace the Personal Transformers in the armor/vehicle.
    - Currently quality is not accounted for when counting equipment in grids. And I'm hoping for an update to the API as opposed to rewriting a large portion.
    - Request for API update: https://forums.factorio.com/viewtopic.php?f=28&t=118603

