### PR TITLE
Space station consumption fix

### DIFF
--- a/PersonalTransformer2/changelog.txt
+++ b/PersonalTransformer2/changelog.txt
@@ -1,4 +1,14 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.0.4
+  Bugfix:
+    - Fixed issue where Personal Transformer would be giving/consuming power while riding/viewing a space station.
+  Current Bugs:
+    - Putting on armor or placing a vehicle with Personal Transformers in them will upgrade all Personal Transformers to Legendary Quality.
+    - To revert to the actual quality, take out and replace the Personal Transformers in the armor/vehicle.
+    - Currently quality is not accounted for when counting equipment in grids. And I'm hoping for an update to the API as opposed to rewriting a large portion.
+    - Request for API update: https://forums.factorio.com/viewtopic.php?f=28&t=118603
+
+---------------------------------------------------------------------------------------------------
 Version: 1.0.3
   Bugfix:
     - Fixed issue where quality was not accounted for.

--- a/PersonalTransformer2/control.lua
+++ b/PersonalTransformer2/control.lua
@@ -279,7 +279,7 @@ script.on_event(defines.events.script_raised_destroy,
 
 script.on_event(defines.events.on_player_changed_surface, 
 	function(event)
---		log ('on_player_changed_surface start --- ')
+		log ('on_player_changed_surface start --- ')
 	-- Need to remove entities and re-add them on new surface
 	-- Might want to only do this if character leaves surface, not player
 		playerOrArmorChanged(event.player_index)
@@ -843,7 +843,15 @@ end
 function playerOrArmorChanged(player_index)
 --log ('playerOrArmorChanged --- START --- storage.transformer_data: ' .. serpent.block(storage.transformer_data))
 	local player = game.players[player_index]
+--log ('playerOrArmorChanged --- player: ' .. serpent.block(player))
+--log ('playerOrArmorChanged --- player.controller: ' .. serpent.block(player.controller_type))
 	if player.character ~= nil then
+
+		-- NOTE: may need to change this for SE when it's ready for 2.0
+		if player.controller_type == defines.controllers.remote then
+			return
+		end
+
 		toggleShortcutAvailable(player, true)
 		-- Search table for previously equipped armor and remove it from the table
 		for grid_id, transformer_data_values in pairs(storage.transformer_data) do

--- a/PersonalTransformer2/info.json
+++ b/PersonalTransformer2/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "PersonalTransformer2",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"title": "Personal Transformer2",
 	"author": "Pikachar",
 	


### PR DESCRIPTION
Version: 1.0.4
  Bugfix:
    - Fixed issue where Personal Transformer would be giving/consuming power while riding/viewing a space station.
  Current Bugs:
    - Putting on armor or placing a vehicle with Personal Transformers in them will upgrade all Personal Transformers to Legendary Quality.
    - To revert to the actual quality, take out and replace the Personal Transformers in the armor/vehicle.
    - Currently quality is not accounted for when counting equipment in grids. And I'm hoping for an update to the API as opposed to rewriting a large portion.
    - Request for API update: https://forums.factorio.com/viewtopic.php?f=28&t=118603
