### PR TITLE
Quality Disabled Fix

### DIFF
--- a/PersonalTransformer2/changelog.txt
+++ b/PersonalTransformer2/changelog.txt
@@ -1,4 +1,15 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.0.5
+  Bugfix:
+    - Fixed crash caused by previous update when quality is not enabled.
+  Current Bugs:
+    - Putting on armor or placing a vehicle with Personal Transformers in them will upgrade all Personal Transformers to Legendary Quality.
+	- If Jetpack mod is installed, jetpacking will have the same effect.
+    - To revert to the actual quality, take out and replace the Personal Transformers in the armor/vehicle.
+    - Currently quality is not accounted for when counting equipment in grids. And I'm hoping for an update to the API as opposed to rewriting a large portion.
+    - Request for API update: https://forums.factorio.com/viewtopic.php?f=28&t=118603
+
+---------------------------------------------------------------------------------------------------
 Version: 1.0.4
   Bugfix:
     - Fixed issue where Personal Transformer would be giving/consuming power while riding/viewing a space station.

--- a/PersonalTransformer2/control.lua
+++ b/PersonalTransformer2/control.lua
@@ -48,6 +48,8 @@ local pt_entity_event_filters = {
 	{filter = "name", name = "personal-transformer-mk3-output-entity"}
 }
 
+local is_quality_enabled = script.active_mods["quality"] 
+
 
 --[[
 	storage.transformer_data[grid_id] = {
@@ -550,6 +552,9 @@ function is_personal_transformer_name_match(name)
 end
 
 function insert_entity(equipment_name, grid_owner, grid_id, quality_name)
+	if not is_quality_enabled then
+		quality_name = "normal"
+	end
 	if is_personal_transformer_name_match(equipment_name) then
 		local entity_input_name
 		local entity_output_name

--- a/PersonalTransformer2/info.json
+++ b/PersonalTransformer2/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "PersonalTransformer2",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"title": "Personal Transformer2",
 	"author": "Pikachar",
 	
@@ -9,6 +9,7 @@
 	"factorio_version": "2.0",
 	"dependencies":
 	[
-		"base >= 2.0"
+		"base >= 2.0",
+		"(?) quality"
 	]
 }


### PR DESCRIPTION
Version: 1.0.5
  Bugfix:
    - Fixed crash caused by previous update when quality is not enabled.
  Current Bugs:
    - Putting on armor or placing a vehicle with Personal Transformers in them will upgrade all Personal Transformers to Legendary Quality.
	- If Jetpack mod is installed, jetpacking will have the same effect.
    - To revert to the actual quality, take out and replace the Personal Transformers in the armor/vehicle.
    - Currently quality is not accounted for when counting equipment in grids. And I'm hoping for an update to the API as opposed to rewriting a large portion.
    - Request for API update: https://forums.factorio.com/viewtopic.php?f=28&t=118603
