### PR TITLE
Added optional dependency for quality

### DIFF
--- a/PersonalTransformer2/changelog.txt
+++ b/PersonalTransformer2/changelog.txt
@@ -1,4 +1,15 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.0.6
+  Feature:
+    - Added optional dependency for quality mod.
+  Current Bugs:
+    - Putting on armor or placing a vehicle with Personal Transformers in them will upgrade all Personal Transformers to Legendary Quality.
+	- If Jetpack mod is installed, jetpacking will have the same effect.
+    - To revert to the actual quality, take out and replace the Personal Transformers in the armor/vehicle.
+    - Currently quality is not accounted for when counting equipment in grids. And I'm hoping for an update to the API as opposed to rewriting a large portion.
+    - Request for API update: https://forums.factorio.com/viewtopic.php?f=28&t=118603
+
+---------------------------------------------------------------------------------------------------
 Version: 1.0.5
   Bugfix:
     - Fixed crash caused by previous update when quality is not enabled.

--- a/PersonalTransformer2/info.json
+++ b/PersonalTransformer2/info.json
@@ -10,6 +10,6 @@
 	"dependencies":
 	[
 		"base >= 2.0",
-		"(?) quality"
+		"? quality"
 	]
 }


### PR DESCRIPTION
Version: 1.0.6
  Feature:
    - Added optional dependency for quality mod.
  Current Bugs:
    - Putting on armor or placing a vehicle with Personal Transformers in them will upgrade all Personal Transformers to Legendary Quality.
	- If Jetpack mod is installed, jetpacking will have the same effect.
    - To revert to the actual quality, take out and replace the Personal Transformers in the armor/vehicle.
    - Currently quality is not accounted for when counting equipment in grids. And I'm hoping for an update to the API as opposed to rewriting a large portion.
    - Request for API update: https://forums.factorio.com/viewtopic.php?f=28&t=118603
