### PR TITLE
Change Teleport If statement

### DIFF
--- a/PersonalTransformer2/control.lua
+++ b/PersonalTransformer2/control.lua
@@ -776,7 +776,7 @@ end
 function teleportEntitiesToPlayerPosition(player_pos, grid_transformer_entities)
 -- NOTE: teleport across surfaces only works for players, cars, and spidertrons
 	for _, pt_entity in pairs(grid_transformer_entities) do
-		if pt_entity.position ~= player_pos then
+		if pt_entity.position.x ~= player_pos.x or pt_entity.position.y ~= player_pos.y then
 			pt_entity.teleport(player_pos)
 		end
 	end


### PR DESCRIPTION
The previous If statement would always fail so i broke out the components and compared them for a working guard case

This reduces the memory leak that i was experiencing so now it only happens if im constantly moving in 3 unconnected electric grids (rare) The leak still exists and it is cumulative but taking off your armor and putting it back on clears the leaked memory