### PR TITLE
Memory leak

### DIFF
--- a/PersonalTransformer2/changelog.txt
+++ b/PersonalTransformer2/changelog.txt
@@ -1,4 +1,18 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.0.8
+  Bugfix:
+    - Fixed memory leak when standing within 3 or more power networks at the same time.
+  Current Bugs:
+    - Putting on armor or placing a vehicle with Personal Transformers in them will upgrade all Personal Transformers to Legendary Quality.
+	- If Jetpack mod is installed, jetpacking will have the same effect.
+    - To revert to the actual quality, take out and replace the Personal Transformers in the armor/vehicle.
+    - Currently quality is not accounted for when counting equipment in grids. And I'm hoping for an update to the API as opposed to rewriting a large portion.
+    - Request for API update: https://forums.factorio.com/viewtopic.php?f=28&t=118603
+    - Currently if moving within 3 power networks at the same time the memory leak still occurs.
+  Special Thanks: 
+    - Thanks to kaseyawolf2 for finding and fixing the multi-network memory leak.
+
+---------------------------------------------------------------------------------------------------
 Version: 1.0.7
   Bugfix:
     - Fixed issue with PTs not getting battery charge to 100%.

--- a/PersonalTransformer2/control.lua
+++ b/PersonalTransformer2/control.lua
@@ -776,7 +776,7 @@ end
 function teleportEntitiesToPlayerPosition(player_pos, grid_transformer_entities)
 -- NOTE: teleport across surfaces only works for players, cars, and spidertrons
 	for _, pt_entity in pairs(grid_transformer_entities) do
-		if pt_entity.position ~= player_pos then
+		if pt_entity.position.x ~= player_pos.x or pt_entity.position.y ~= player_pos.y then
 			pt_entity.teleport(player_pos)
 		end
 	end

--- a/PersonalTransformer2/info.json
+++ b/PersonalTransformer2/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "PersonalTransformer2",
-	"version": "1.0.7",
+	"version": "1.0.8",
 	"title": "Personal Transformer2",
 	"author": "Pikachar",
 	


### PR DESCRIPTION
Version: 1.0.8
  Bugfix:
    - Fixed memory leak when standing within 3 or more power networks at the same time.
  Current Bugs:
    - Putting on armor or placing a vehicle with Personal Transformers in them will upgrade all Personal Transformers to Legendary Quality.
	- If Jetpack mod is installed, jetpacking will have the same effect.
    - To revert to the actual quality, take out and replace the Personal Transformers in the armor/vehicle.
    - Currently quality is not accounted for when counting equipment in grids. And I'm hoping for an update to the API as opposed to rewriting a large portion.
    - Request for API update: https://forums.factorio.com/viewtopic.php?f=28&t=118603
    - Currently if moving within 3 power networks at the same time the memory leak still occurs.
  Special Thanks: 
    - Thanks to kaseyawolf2 for finding and fixing the multi-network memory leak.