### PR TITLE
Fixed crash caused by leaving Compact Circuits editor

### DIFF
--- a/PersonalTransformer2/control.lua
+++ b/PersonalTransformer2/control.lua
@@ -634,7 +634,9 @@ function remove_entity(equipment_name, grid_id)
 --log ('remove_entity --- entity: ' .. serpent.block(entity))
 --log ('remove_entity --- entity.name: ' .. serpent.block(entity.name))
 --log ('remove_entity --- entity.unit_number: ' .. serpent.block(entity.unit_number))
-			if (entity.name == entity_input_name) then
+			if (not entity.valid) then
+				table.remove(storage.transformer_data[grid_id].grid_transformer_entities, index)
+			elseif (entity.name == entity_input_name) then
 				local entity = table.remove(storage.transformer_data[grid_id].grid_transformer_entities, index)
 --				log ('remove_entity --- entity: ' .. serpent.block(entity))
 				entity.destroy()
@@ -651,7 +653,9 @@ function remove_entity(equipment_name, grid_id)
 --log ('remove_entity --- entity.name: ' .. serpent.block(entity.name))
 --log ('remove_entity --- entity.name: ' .. serpent.block(entity.name))
 --log ('remove_entity --- entity.unit_number: ' .. serpent.block(entity.unit_number))
-			if (entity.name == entity_output_name) then
+			if (not entity.valid) then
+				table.remove(storage.transformer_data[grid_id].grid_transformer_entities, index)
+			elseif (entity.name == entity_output_name) then
 				local entity = table.remove(storage.transformer_data[grid_id].grid_transformer_entities, index)
 --				log ('remove_entity --- entity: ' .. serpent.block(entity))
 				entity.destroy()


### PR DESCRIPTION
Current implementation of remove_entity can't handle surfaces being deleted upon leaving them. Fix forgets transformer entities when they've already been destroyed by other mods.

Crash log:
```
Error while running event PersonalTransformer2::on_player_changed_surface (ID 54)
LuaEntity API call when LuaEntity was invalid.
stack traceback:
[C]: in function 'index'
__PersonalTransformer2/control.lua:637: in function 'remove_entity'
PersonalTransformer2/control.lua:827: in function 'equipmentRemoved'
PersonalTransformer2/control.lua:873: in function 'playerOrArmorChanged'
PersonalTransformer2/control.lua:287: in function <PersonalTransformer2/control.lua:283>
```