### PR TITLE
Compact Circuits Crash fix

### DIFF
--- a/PersonalTransformer2/changelog.txt
+++ b/PersonalTransformer2/changelog.txt
@@ -1,4 +1,18 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.0.9
+  Bugfix:
+    - Fixed issue with Compact Circuits and other compact surface mods.
+  Current Bugs:
+    - Putting on armor or placing a vehicle with Personal Transformers in them will upgrade all Personal Transformers to Legendary Quality.
+    - If Jetpack mod is installed, jetpacking will have the same effect.
+    - To revert to the actual quality, take out and replace the Personal Transformers in the armor/vehicle.
+    - Currently quality is not accounted for when counting equipment in grids. And I'm hoping for an update to the API as opposed to rewriting a large portion.
+    - Request for API update: https://forums.factorio.com/viewtopic.php?f=28&t=118603
+    - Currently if moving within 3 power networks at the same time the memory leak still occurs.
+  Special Thanks: 
+    - Thanks to Elec for finding and providing the fix for the Compact Circuits crash.
+
+---------------------------------------------------------------------------------------------------
 Version: 1.0.8
   Bugfix:
     - Fixed memory leak when standing within 3 or more power networks at the same time.

--- a/PersonalTransformer2/changelog.txt
+++ b/PersonalTransformer2/changelog.txt
@@ -4,7 +4,7 @@ Version: 1.0.8
     - Fixed memory leak when standing within 3 or more power networks at the same time.
   Current Bugs:
     - Putting on armor or placing a vehicle with Personal Transformers in them will upgrade all Personal Transformers to Legendary Quality.
-	- If Jetpack mod is installed, jetpacking will have the same effect.
+    - If Jetpack mod is installed, jetpacking will have the same effect.
     - To revert to the actual quality, take out and replace the Personal Transformers in the armor/vehicle.
     - Currently quality is not accounted for when counting equipment in grids. And I'm hoping for an update to the API as opposed to rewriting a large portion.
     - Request for API update: https://forums.factorio.com/viewtopic.php?f=28&t=118603
@@ -19,7 +19,7 @@ Version: 1.0.7
     - Fixed issue with exoskeletons not working while PTs were in armor and Input was enabled.
   Current Bugs:
     - Putting on armor or placing a vehicle with Personal Transformers in them will upgrade all Personal Transformers to Legendary Quality.
-	- If Jetpack mod is installed, jetpacking will have the same effect.
+    - If Jetpack mod is installed, jetpacking will have the same effect.
     - To revert to the actual quality, take out and replace the Personal Transformers in the armor/vehicle.
     - Currently quality is not accounted for when counting equipment in grids. And I'm hoping for an update to the API as opposed to rewriting a large portion.
     - Request for API update: https://forums.factorio.com/viewtopic.php?f=28&t=118603
@@ -30,7 +30,7 @@ Version: 1.0.6
     - Added optional dependency for quality mod.
   Current Bugs:
     - Putting on armor or placing a vehicle with Personal Transformers in them will upgrade all Personal Transformers to Legendary Quality.
-	- If Jetpack mod is installed, jetpacking will have the same effect.
+    - If Jetpack mod is installed, jetpacking will have the same effect.
     - To revert to the actual quality, take out and replace the Personal Transformers in the armor/vehicle.
     - Currently quality is not accounted for when counting equipment in grids. And I'm hoping for an update to the API as opposed to rewriting a large portion.
     - Request for API update: https://forums.factorio.com/viewtopic.php?f=28&t=118603
@@ -41,7 +41,7 @@ Version: 1.0.5
     - Fixed crash caused by previous update when quality is not enabled.
   Current Bugs:
     - Putting on armor or placing a vehicle with Personal Transformers in them will upgrade all Personal Transformers to Legendary Quality.
-	- If Jetpack mod is installed, jetpacking will have the same effect.
+    - If Jetpack mod is installed, jetpacking will have the same effect.
     - To revert to the actual quality, take out and replace the Personal Transformers in the armor/vehicle.
     - Currently quality is not accounted for when counting equipment in grids. And I'm hoping for an update to the API as opposed to rewriting a large portion.
     - Request for API update: https://forums.factorio.com/viewtopic.php?f=28&t=118603

--- a/PersonalTransformer2/control.lua
+++ b/PersonalTransformer2/control.lua
@@ -634,7 +634,8 @@ function remove_entity(equipment_name, grid_id)
 --log ('remove_entity --- entity: ' .. serpent.block(entity))
 --log ('remove_entity --- entity.name: ' .. serpent.block(entity.name))
 --log ('remove_entity --- entity.unit_number: ' .. serpent.block(entity.unit_number))
-			if (entity.name == entity_input_name) then
+			if ( not entity.valid or entity.name == entity_input_name) then
+--			if (entity.name == entity_input_name) then
 				local entity = table.remove(storage.transformer_data[grid_id].grid_transformer_entities, index)
 --				log ('remove_entity --- entity: ' .. serpent.block(entity))
 				entity.destroy()
@@ -651,7 +652,8 @@ function remove_entity(equipment_name, grid_id)
 --log ('remove_entity --- entity.name: ' .. serpent.block(entity.name))
 --log ('remove_entity --- entity.name: ' .. serpent.block(entity.name))
 --log ('remove_entity --- entity.unit_number: ' .. serpent.block(entity.unit_number))
-			if (entity.name == entity_output_name) then
+			if (not entity.valid or entity.name == entity_output_name) then
+--			if (entity.name == entity_output_name) then
 				local entity = table.remove(storage.transformer_data[grid_id].grid_transformer_entities, index)
 --				log ('remove_entity --- entity: ' .. serpent.block(entity))
 				entity.destroy()

--- a/PersonalTransformer2/info.json
+++ b/PersonalTransformer2/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "PersonalTransformer2",
-	"version": "1.0.8",
+	"version": "1.0.9",
 	"title": "Personal Transformer2",
 	"author": "Pikachar",
 	


### PR DESCRIPTION
Version: 1.0.9
  Bugfix:
    - Fixed issue with Compact Circuits and other compact surface mods.
  Current Bugs:
    - Putting on armor or placing a vehicle with Personal Transformers in them will upgrade all Personal Transformers to Legendary Quality.
    - If Jetpack mod is installed, jetpacking will have the same effect.
    - To revert to the actual quality, take out and replace the Personal Transformers in the armor/vehicle.
    - Currently quality is not accounted for when counting equipment in grids. And I'm hoping for an update to the API as opposed to rewriting a large portion.
    - Request for API update: https://forums.factorio.com/viewtopic.php?f=28&t=118603
    - Currently if moving within 3 power networks at the same time the memory leak still occurs.
  Special Thanks: 
    - Thanks to Elec for finding and providing the fix for the Compact Circuits crash.
    https://github.com/Pikachar2/PersonalTransformer/pull/35/files