### PR TITLE
V 1.0.9

### DIFF
--- a/PersonalTransformer2/changelog.txt
+++ b/PersonalTransformer2/changelog.txt
@@ -1,6 +1,7 @@
 ---------------------------------------------------------------------------------------------------
 Version: 1.0.9
   Bugfix:
+    - Fixed issue with PT not charging/discharging while in remote view.
     - Fixed issue with Compact Circuits and other compact surface mods.
   Current Bugs:
     - Putting on armor or placing a vehicle with Personal Transformers in them will upgrade all Personal Transformers to Legendary Quality.

--- a/PersonalTransformer2/changelog.txt
+++ b/PersonalTransformer2/changelog.txt
@@ -1,4 +1,18 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.0.9
+  Bugfix:
+    - Fixed issue with Compact Circuits and other compact surface mods.
+  Current Bugs:
+    - Putting on armor or placing a vehicle with Personal Transformers in them will upgrade all Personal Transformers to Legendary Quality.
+    - If Jetpack mod is installed, jetpacking will have the same effect.
+    - To revert to the actual quality, take out and replace the Personal Transformers in the armor/vehicle.
+    - Currently quality is not accounted for when counting equipment in grids. And I'm hoping for an update to the API as opposed to rewriting a large portion.
+    - Request for API update: https://forums.factorio.com/viewtopic.php?f=28&t=118603
+    - Currently if moving within 3 power networks at the same time the memory leak still occurs.
+  Special Thanks: 
+    - Thanks to Elec for finding and providing the fix for the Compact Circuits crash.
+
+---------------------------------------------------------------------------------------------------
 Version: 1.0.8
   Bugfix:
     - Fixed memory leak when standing within 3 or more power networks at the same time.

--- a/PersonalTransformer2/changelog.txt
+++ b/PersonalTransformer2/changelog.txt
@@ -4,7 +4,7 @@ Version: 1.0.8
     - Fixed memory leak when standing within 3 or more power networks at the same time.
   Current Bugs:
     - Putting on armor or placing a vehicle with Personal Transformers in them will upgrade all Personal Transformers to Legendary Quality.
-	- If Jetpack mod is installed, jetpacking will have the same effect.
+    - If Jetpack mod is installed, jetpacking will have the same effect.
     - To revert to the actual quality, take out and replace the Personal Transformers in the armor/vehicle.
     - Currently quality is not accounted for when counting equipment in grids. And I'm hoping for an update to the API as opposed to rewriting a large portion.
     - Request for API update: https://forums.factorio.com/viewtopic.php?f=28&t=118603
@@ -19,7 +19,7 @@ Version: 1.0.7
     - Fixed issue with exoskeletons not working while PTs were in armor and Input was enabled.
   Current Bugs:
     - Putting on armor or placing a vehicle with Personal Transformers in them will upgrade all Personal Transformers to Legendary Quality.
-	- If Jetpack mod is installed, jetpacking will have the same effect.
+    - If Jetpack mod is installed, jetpacking will have the same effect.
     - To revert to the actual quality, take out and replace the Personal Transformers in the armor/vehicle.
     - Currently quality is not accounted for when counting equipment in grids. And I'm hoping for an update to the API as opposed to rewriting a large portion.
     - Request for API update: https://forums.factorio.com/viewtopic.php?f=28&t=118603
@@ -30,7 +30,7 @@ Version: 1.0.6
     - Added optional dependency for quality mod.
   Current Bugs:
     - Putting on armor or placing a vehicle with Personal Transformers in them will upgrade all Personal Transformers to Legendary Quality.
-	- If Jetpack mod is installed, jetpacking will have the same effect.
+    - If Jetpack mod is installed, jetpacking will have the same effect.
     - To revert to the actual quality, take out and replace the Personal Transformers in the armor/vehicle.
     - Currently quality is not accounted for when counting equipment in grids. And I'm hoping for an update to the API as opposed to rewriting a large portion.
     - Request for API update: https://forums.factorio.com/viewtopic.php?f=28&t=118603
@@ -41,7 +41,7 @@ Version: 1.0.5
     - Fixed crash caused by previous update when quality is not enabled.
   Current Bugs:
     - Putting on armor or placing a vehicle with Personal Transformers in them will upgrade all Personal Transformers to Legendary Quality.
-	- If Jetpack mod is installed, jetpacking will have the same effect.
+    - If Jetpack mod is installed, jetpacking will have the same effect.
     - To revert to the actual quality, take out and replace the Personal Transformers in the armor/vehicle.
     - Currently quality is not accounted for when counting equipment in grids. And I'm hoping for an update to the API as opposed to rewriting a large portion.
     - Request for API update: https://forums.factorio.com/viewtopic.php?f=28&t=118603

--- a/PersonalTransformer2/control.lua
+++ b/PersonalTransformer2/control.lua
@@ -364,7 +364,7 @@ function update_personal_transformer(tickdelay, transformer_data)
 
 			if player.character ~= nil then
 				-- teleport entities to player
-				teleportEntitiesToPlayerPosition(player.position, transformer_data_values.grid_transformer_entities)
+				teleportEntitiesToPlayerPosition(player.position, player, "player", transformer_data_values.grid_transformer_entities)
 				local grid = player.character.grid
 				if grid ~= nil then
 				-- perform math
@@ -478,7 +478,7 @@ function update_vehicle_transformer(tickdelay, transformer_data)
 --log ('update_vehicle_transformer --- grid_id = '.. serpent.block(grid_id))
 --log ('update_vehicle_transformer --- vehicle.position = '.. serpent.block(vehicle.position))
 --log ('update_vehicle_transformer --- transformer_data_values.grid_transformer_entities = '.. serpent.block(transformer_data_values.grid_transformer_entities))
-				teleportEntitiesToPlayerPosition(vehicle.position, transformer_data_values.grid_transformer_entities)
+				teleportEntitiesToPlayerPosition(vehicle.position, vehicle, "entity", transformer_data_values.grid_transformer_entities)
 				local grid = vehicle.grid
 				if grid ~= nil then
 				-- perform math
@@ -775,11 +775,14 @@ function isPlayerOwnerOfGrid(grid_id)
 	return nil
 end
 
-function teleportEntitiesToPlayerPosition(player_pos, grid_transformer_entities)
+function teleportEntitiesToPlayerPosition(entity_pos, entity, entity_type, grid_transformer_entities)
 -- NOTE: teleport across surfaces only works for players, cars, and spidertrons
+	if entity_type == "player" and entity.controller_type == defines.controllers.remote then
+		return
+	end
 	for _, pt_entity in pairs(grid_transformer_entities) do
-		if pt_entity.position.x ~= player_pos.x or pt_entity.position.y ~= player_pos.y then
-			pt_entity.teleport(player_pos)
+		if pt_entity.position.x ~= entity_pos.x or pt_entity.position.y ~= entity_pos.y then
+			pt_entity.teleport(entity_pos)
 		end
 	end
 end
@@ -857,8 +860,9 @@ end
 function playerOrArmorChanged(player_index)
 --log ('playerOrArmorChanged --- START --- storage.transformer_data: ' .. serpent.block(storage.transformer_data))
 	local player = game.players[player_index]
---log ('playerOrArmorChanged --- player: ' .. serpent.block(player))
---log ('playerOrArmorChanged --- player.controller: ' .. serpent.block(player.controller_type))
+log ('playerOrArmorChanged --- player: ' .. serpent.block(player))
+log ('playerOrArmorChanged --- player.character: ' .. serpent.block(player.character))
+log ('playerOrArmorChanged --- player.controller: ' .. serpent.block(player.controller_type))
 	if player.character ~= nil then
 
 		-- NOTE: may need to change this for SE when it's ready for 2.0

--- a/PersonalTransformer2/control.lua
+++ b/PersonalTransformer2/control.lua
@@ -860,9 +860,9 @@ end
 function playerOrArmorChanged(player_index)
 --log ('playerOrArmorChanged --- START --- storage.transformer_data: ' .. serpent.block(storage.transformer_data))
 	local player = game.players[player_index]
-log ('playerOrArmorChanged --- player: ' .. serpent.block(player))
-log ('playerOrArmorChanged --- player.character: ' .. serpent.block(player.character))
-log ('playerOrArmorChanged --- player.controller: ' .. serpent.block(player.controller_type))
+--log ('playerOrArmorChanged --- player: ' .. serpent.block(player))
+--log ('playerOrArmorChanged --- player.character: ' .. serpent.block(player.character))
+--log ('playerOrArmorChanged --- player.controller: ' .. serpent.block(player.controller_type))
 	if player.character ~= nil then
 
 		-- NOTE: may need to change this for SE when it's ready for 2.0

--- a/PersonalTransformer2/control.lua
+++ b/PersonalTransformer2/control.lua
@@ -634,7 +634,8 @@ function remove_entity(equipment_name, grid_id)
 --log ('remove_entity --- entity: ' .. serpent.block(entity))
 --log ('remove_entity --- entity.name: ' .. serpent.block(entity.name))
 --log ('remove_entity --- entity.unit_number: ' .. serpent.block(entity.unit_number))
-			if (entity.name == entity_input_name) then
+			if ( not entity.valid or entity.name == entity_input_name) then
+--			if (entity.name == entity_input_name) then
 				local entity = table.remove(storage.transformer_data[grid_id].grid_transformer_entities, index)
 --				log ('remove_entity --- entity: ' .. serpent.block(entity))
 				entity.destroy()
@@ -651,7 +652,8 @@ function remove_entity(equipment_name, grid_id)
 --log ('remove_entity --- entity.name: ' .. serpent.block(entity.name))
 --log ('remove_entity --- entity.name: ' .. serpent.block(entity.name))
 --log ('remove_entity --- entity.unit_number: ' .. serpent.block(entity.unit_number))
-			if (entity.name == entity_output_name) then
+			if (not entity.valid or entity.name == entity_output_name) then
+--			if (entity.name == entity_output_name) then
 				local entity = table.remove(storage.transformer_data[grid_id].grid_transformer_entities, index)
 --				log ('remove_entity --- entity: ' .. serpent.block(entity))
 				entity.destroy()

--- a/PersonalTransformer2/info.json
+++ b/PersonalTransformer2/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "PersonalTransformer2",
-	"version": "1.0.8",
+	"version": "1.0.9",
 	"title": "Personal Transformer2",
 	"author": "Pikachar",
 	


### PR DESCRIPTION
---------------------------------------------------------------------------------------------------
Version: 1.0.9
  Bugfix:
    - Fixed issue with PT not charging/discharging while in remote view.
    - Fixed issue with Compact Circuits and other compact surface mods.
  Current Bugs:
    - Putting on armor or placing a vehicle with Personal Transformers in them will upgrade all Personal Transformers to Legendary Quality.
    - If Jetpack mod is installed, jetpacking will have the same effect.
    - To revert to the actual quality, take out and replace the Personal Transformers in the armor/vehicle.
    - Currently quality is not accounted for when counting equipment in grids. And I'm hoping for an update to the API as opposed to rewriting a large portion.
    - Request for API update: https://forums.factorio.com/viewtopic.php?f=28&t=118603
    - Currently if moving within 3 power networks at the same time the memory leak still occurs.
  Special Thanks: 
    - Thanks to Elec for finding and providing the fix for the Compact Circuits crash.

